### PR TITLE
Only test a sample of wp sections

### DIFF
--- a/test/com.washingtonpost.js
+++ b/test/com.washingtonpost.js
@@ -11,9 +11,23 @@ function assertNonEmptyString(what) {
     assert(typeof what === 'string' && what, 'Expected a non-empty string, got ' + what);
 }
 
+function sample(arr, size) {
+    let shuffled = arr.slice(0), i = arr.length, temp, index;
+    while (i--) {
+        index = Math.floor((i + 1) * Math.random());
+        temp = shuffled[index];
+        shuffled[index] = shuffled[i];
+        shuffled[i] = temp;
+    }
+    return shuffled.slice(0, size);
+}
+
+
 module.exports = [];
 
-for (let section of `politics,opinions,local,sports,national,world,business,lifestyle`.split(',')) {
+const articleSections = `politics,opinions,local,sports,national,world,business,lifestyle`.split(',');
+for (let section of sample(articleSections, 3)) {
+    console.log(`Testing wp section: ${section}`);
     module.exports.push(['query', 'get_article', { section }, (results) => {
         for (let result of results) {
             assertNonEmptyString(result.title);
@@ -24,7 +38,10 @@ for (let section of `politics,opinions,local,sports,national,world,business,life
         }
     }]);
 }
-for (let section of `the_fix,politics,powerpost,fact_checker,world_views,compost,the_plum_line,post_partisan,post_everything,right_turn,capital_weather_gang,morning_mix,wonkblog`.split(',')) {
+
+const blogSections = `the_fix,politics,powerpost,fact_checker,world_views,compost,the_plum_line,post_partisan,post_everything,right_turn,capital_weather_gang,morning_mix,wonkblog`.split(',');
+for (let section of sample(blogSections, 3)) {
+    console.log(`Testing wp blog section: ${section}`);
     module.exports.push(['query', 'get_blog_post', { section }, (results) => {
         const oneWeekAgo = new Date;
         oneWeekAgo.setTime(oneWeekAgo.getTime() - 7 * 3600 * 24 * 1000);


### PR DESCRIPTION
The washingto post rss has been very slow and very often blocsk us.
Instead of testing all 20+ sections we support, only test a random sample.