### PR TITLE
io.home-assistant: warn only once for yet unsupported entities

### DIFF
--- a/io.home-assistant/index.js
+++ b/io.home-assistant/index.js
@@ -72,6 +72,7 @@ class HomeAssistantDeviceSet extends Tp.Helpers.ObjectSet.Base {
         super();
         this.master = master;
         this._devices = new Map;
+        this._warned = new Set;
 
         this._unsubscribe = null;
     }
@@ -108,7 +109,10 @@ class HomeAssistantDeviceSet extends Tp.Helpers.ObjectSet.Base {
             kind = DOMAIN_TO_TP_KIND[domain];
 
         if (kind === undefined) {
-            console.log(`Unhandled Home Assistant entity ${entityId} with domain ${domain}`);
+            if (!this._warned.has(entityId)) {
+                console.log(`Unhandled Home Assistant entity ${entityId} with domain ${domain}`);
+                this._warned.add(entityId);
+            }
             return;
         }
         const deviceClass = SUBDEVICES[kind];

--- a/io.home-assistant/index.js
+++ b/io.home-assistant/index.js
@@ -110,7 +110,7 @@ class HomeAssistantDeviceSet extends Tp.Helpers.ObjectSet.Base {
 
         if (kind === undefined) {
             if (!this._warned.has(entityId)) {
-                console.log(`Unhandled Home Assistant entity ${entityId} with domain ${domain}`);
+                console.log(`Unhandled Home Assistant entity ${entityId} with domain ${domain} and device class ${attributes.device_class}`);
                 this._warned.add(entityId);
             }
             return;


### PR DESCRIPTION
Otherwise, we warn every time the entity state changes, and for
some entities that is constantly, which hammers our disk in almond-cloud,
and hammers people's disks in almond-server