### PR TITLE
Filter out Home Assistant entities without a friendly name

### DIFF
--- a/io.home-assistant/index.js
+++ b/io.home-assistant/index.js
@@ -86,6 +86,11 @@ class HomeAssistantDeviceSet extends Tp.Helpers.ObjectSet.Base {
             });
             return;
         }
+        
+        // Do not add entities without a friendly name.
+        if (!attributes.friendly_name) {
+            return;
+        }
 
         const [domain,] = entityId.split('.');
         let kind = undefined;


### PR DESCRIPTION
Not all Home Assistant entities have a friendly name. We should not map those to Almond because we can't refer to them by voice. 