### PR TITLE
io.home-assistant: fix creating subdevices

### DIFF
--- a/io.home-assistant/index.js
+++ b/io.home-assistant/index.js
@@ -122,7 +122,7 @@ class HomeAssistantDeviceSet extends Tp.Helpers.ObjectSet.Base {
         }
         const deviceClass = SUBDEVICES[kind];
         const device = new deviceClass(
-            this.engine, { kind, state, attributes }, this.master, entityId);
+            this.master.engine, { kind, state, attributes }, this.master, entityId);
         this._devices.set(entityId, device);
         this.objectAdded(device);
     }


### PR DESCRIPTION
this.engine is not defined anywhere, and the latest version of
the SDK is more fussy that the first argument of a device must
be an Engine.