### PR TITLE
updated evaluation set and spotify skill

### DIFF
--- a/main/com.spotify/eval/dev/annotated.txt
+++ b/main/com.spotify/eval/dev/annotated.txt
@@ -1,221 +1,4 @@
 ====
-# online/spotify-1
-U: turn off repeat.
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.player_repeat(repeat=enum(off));
-====
-# online/spotify-110
-U: play the song stairway to heaven
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.spotify.song()), id =~ "stairway to heaven" => notify;
-UT: now => @com.spotify.play_song(song=$?);
-====
-# online/spotify-114
-U: what track is currently playing on spotify?
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.get_currently_playing() => notify;
-====
-# online/spotify-35
-U: play something by the smashing pumpkins
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.spotify.artist()), id =~ "smashing pumpkins" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
-====
-# online/1674005
-U: resume my spotify
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.player_play();
-====
-# online/1675050
-U: play songs by the beatles
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.spotify.artist()), id =~ "the beatles" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
-====
-# online/1678056
-U: set shuffle on
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.player_shuffle(shuffle=enum(on));
-====
-# online/16013786
-U: find me songs of kanye west
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.spotify.artist()), id =~ "kanye west" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
-====
-# online/32582189
-U: play the song not afraid
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.spotify.song()), id =~ "not afraid" => notify;
-UT: now => @com.spotify.play_song(song=$?);
-====
-# 2
-U: what is drake's most popular song ?
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (sort popularity desc of (@com.spotify.song())), contains~(artists, "drake") => notify;
-C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: now => (sort popularity desc of (@com.spotify.song())), contains~(artists, "drake") => notify
-C: #[results=[
-C:   { id="spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2020-04-03T00:00:00.000Z"), popularity=93, energy=45, danceability=83 },
-C:   { id="spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2020-04-03T00:00:00.000Z"), popularity=93, energy=45, danceability=83 },
-C:   { id="spotify:track:466cKvZn1j45IpxDdYZqdA"^^com.spotify:song("Toosie Slide"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=86, energy=49, danceability=83 },
-C:   { id="spotify:track:4wVOKKEHUJxHCFFNUWDn0B"^^com.spotify:song("Chicago Freestyle (feat. Giveon)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:4fxd5Ee7UefO4CUXgwJ7IP"^^com.spotify:artist("Giveon")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=88, energy=44, danceability=73 },
-C:   { id="spotify:track:4wVOKKEHUJxHCFFNUWDn0B"^^com.spotify:song("Chicago Freestyle (feat. Giveon)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:4fxd5Ee7UefO4CUXgwJ7IP"^^com.spotify:artist("Giveon")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=88, energy=44, danceability=73 },
-C:   { id="spotify:track:5ry2OE6R2zPQFDO85XkgRb"^^com.spotify:song("Money In The Grave (Drake ft. Rick Ross)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:1sBkRIssrMs1AbVkOJbc7a"^^com.spotify:artist("Rick Ross")], release_date=new Date("2019-06-15T00:00:00.000Z"), popularity=84, energy=50, danceability=83 },
-C:   { id="spotify:track:6DCZcSspjsKoFjzjrWoCdn"^^com.spotify:song("God's Plan"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2018-06-29T00:00:00.000Z"), popularity=84, energy=44, danceability=75 },
-C:   { id="spotify:track:2G7V7zsVDxg1yRsu7Ew9RJ"^^com.spotify:song("In My Feelings"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2018-06-29T00:00:00.000Z"), popularity=81, energy=62, danceability=83 },
-C:   { id="spotify:track:1zi7xx7UVEFkmKfv06H8x0"^^com.spotify:song("One Dance"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:3tVQdUvClmAT7URs9V3rsp"^^com.spotify:artist("WizKid"), "spotify:artist:77DAFfvm3O9zT5dIoG0eIO"^^com.spotify:artist("Kyla")], release_date=new Date("2016-05-06T00:00:00.000Z"), popularity=81, energy=62, danceability=79 },
-C:   { id="spotify:track:6Kj17Afjo1OKJYpf5VzCeo"^^com.spotify:song("Pain 1993 (with Playboi Carti)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:699OTQXzgjhIYAHMy9RyPD"^^com.spotify:artist("Playboi Carti")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=80, energy=37, danceability=82 }
-C: ]]
-C: #[count=22];
-A: his most popular song right now is toosie slide . would you like to play this song ?
-AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: now => @com.spotify.play_song(song=$?)
-AT: #[confirm=enum(proposed)];
-U: i don't know that song . when was it released ?
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => [release_date] of ((sort popularity desc of (@com.spotify.song())), (contains~(artists, "drake") && id == "spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"))) => notify;
-C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: now => (sort popularity desc of (@com.spotify.song())), contains~(artists, "drake") => notify
-C: #[results=[
-C:   { id="spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2020-04-03T00:00:00.000Z"), popularity=93, energy=45, danceability=83 },
-C:   { id="spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2020-04-03T00:00:00.000Z"), popularity=93, energy=45, danceability=83 },
-C:   { id="spotify:track:466cKvZn1j45IpxDdYZqdA"^^com.spotify:song("Toosie Slide"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=86, energy=49, danceability=83 },
-C:   { id="spotify:track:4wVOKKEHUJxHCFFNUWDn0B"^^com.spotify:song("Chicago Freestyle (feat. Giveon)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:4fxd5Ee7UefO4CUXgwJ7IP"^^com.spotify:artist("Giveon")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=88, energy=44, danceability=73 },
-C:   { id="spotify:track:4wVOKKEHUJxHCFFNUWDn0B"^^com.spotify:song("Chicago Freestyle (feat. Giveon)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:4fxd5Ee7UefO4CUXgwJ7IP"^^com.spotify:artist("Giveon")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=88, energy=44, danceability=73 },
-C:   { id="spotify:track:5ry2OE6R2zPQFDO85XkgRb"^^com.spotify:song("Money In The Grave (Drake ft. Rick Ross)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:1sBkRIssrMs1AbVkOJbc7a"^^com.spotify:artist("Rick Ross")], release_date=new Date("2019-06-15T00:00:00.000Z"), popularity=84, energy=50, danceability=83 },
-C:   { id="spotify:track:6DCZcSspjsKoFjzjrWoCdn"^^com.spotify:song("God's Plan"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2018-06-29T00:00:00.000Z"), popularity=84, energy=44, danceability=75 },
-C:   { id="spotify:track:2G7V7zsVDxg1yRsu7Ew9RJ"^^com.spotify:song("In My Feelings"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], release_date=new Date("2018-06-29T00:00:00.000Z"), popularity=81, energy=62, danceability=83 },
-C:   { id="spotify:track:1zi7xx7UVEFkmKfv06H8x0"^^com.spotify:song("One Dance"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:3tVQdUvClmAT7URs9V3rsp"^^com.spotify:artist("WizKid"), "spotify:artist:77DAFfvm3O9zT5dIoG0eIO"^^com.spotify:artist("Kyla")], release_date=new Date("2016-05-06T00:00:00.000Z"), popularity=81, energy=62, danceability=79 },
-C:   { id="spotify:track:6Kj17Afjo1OKJYpf5VzCeo"^^com.spotify:song("Pain 1993 (with Playboi Carti)"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake"), "spotify:artist:699OTQXzgjhIYAHMy9RyPD"^^com.spotify:artist("Playboi Carti")], release_date=new Date("2020-05-01T00:00:00.000Z"), popularity=80, energy=37, danceability=82 }
-C: ]]
-C: #[count=22];
-C: now => [release_date] of ((sort popularity desc of (@com.spotify.song())), (contains~(artists, "drake") && id == "spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"))) => notify
-C: #[results=[
-C:   { id="spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"), release_date=new Date("2020-04-03T00:00:00.000Z") },
-C:   { id="spotify:track:127QTOFJsJQp5LbJbu3A1y"^^com.spotify:song("Toosie Slide"), release_date=new Date("2020-04-03T00:00:00.000Z") }
-C: ]];
-A: toosie slide was released on april 3rd 2020 .
-AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-U: ok thanks, goodbye .
-UT: $dialogue @org.thingpedia.dialogue.transaction.cancel;
-====
-# 5
-U: hi, i'm having a party later would the song despacito be good for dancing .
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-A: would you like me to get the danceability for despacito by luis fonsi and daddy yankee ?
-AT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-AT: now => [danceability] of ((@com.spotify.song()), id == "spotify:track:6habFhsOp2NvshLv26DqMb"^^com.spotify:song("Despacito")) => notify
-AT: #[confirm=enum(proposed)];
-U: yes .
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => [danceability] of ((@com.spotify.song()), id == "spotify:track:6habFhsOp2NvshLv26DqMb"^^com.spotify:song("Despacito")) => notify;
-C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: now => [danceability] of ((@com.spotify.song()), id == "spotify:track:6habFhsOp2NvshLv26DqMb"^^com.spotify:song("Despacito")) => notify
-C: #[results=[
-C:   { id="spotify:track:6habFhsOp2NvshLv26DqMb"^^com.spotify:song("Despacito"), danceability=65 }
-C: ]];
-A: the danceability is 65 out of 100 . would you like me to play this song ?
-AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: now => @com.spotify.play_song(song="spotify:track:6habFhsOp2NvshLv26DqMb"^^com.spotify:song("Despacito"))
-AT: #[confirm=enum(proposed)];
-U: no thank you, maybe later .
-UT: $dialogue @org.thingpedia.dialogue.transaction.cancel;
-====
-# 6
-U: who was the song 7 rings written by ?
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => [artists] of ((@com.spotify.song()), id =~ "7 rings") => notify;
-C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: now => [artists] of ((@com.spotify.song()), id =~ "7 rings") => notify
-C: #[results=[
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:0YEg2JfkMeJ1hTYqop4A5o"^^com.spotify:song("7 Rings"), artists=["spotify:artist:00YTqRClk82aMchQQpYMd5"^^com.spotify:artist("Our Last Night"), "spotify:artist:4gO25bbcu1eFNi8uDCvJFS"^^com.spotify:artist("Derek DiScanio")] },
-C:   { id="spotify:track:2fOmk4x4OJZsjK60kjW7KZ"^^com.spotify:song("7 Rings"), artists=["spotify:artist:1Vvvx45Apu6dQqwuZQxtgW"^^com.spotify:artist("Kidz Bop Kids")] },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:6va6SjWz457IOZidBppAhz"^^com.spotify:song("7 rings - live"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:6AyI8UGx8Y4peb7pLOy2pf"^^com.spotify:song("7 rings (feat. 2 Chainz) - Remix"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:17lzZA2AlOHwCwFALHttmp"^^com.spotify:artist("2 Chainz")] }
-C: ]];
-A: 7 rings was written by ariana grande . would you like me to play this song ?
-AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: now => @com.spotify.play_song(song="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"))
-AT: #[confirm=enum(proposed)];
-U: no thank you . what other songs has she released ?
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.spotify.song()), contains(artists, "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")) => notify;
-C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: now => [artists] of ((@com.spotify.song()), id =~ "7 rings") => notify
-C: #[results=[
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:0YEg2JfkMeJ1hTYqop4A5o"^^com.spotify:song("7 Rings"), artists=["spotify:artist:00YTqRClk82aMchQQpYMd5"^^com.spotify:artist("Our Last Night"), "spotify:artist:4gO25bbcu1eFNi8uDCvJFS"^^com.spotify:artist("Derek DiScanio")] },
-C:   { id="spotify:track:2fOmk4x4OJZsjK60kjW7KZ"^^com.spotify:song("7 Rings"), artists=["spotify:artist:1Vvvx45Apu6dQqwuZQxtgW"^^com.spotify:artist("Kidz Bop Kids")] },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:6va6SjWz457IOZidBppAhz"^^com.spotify:song("7 rings - live"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:6AyI8UGx8Y4peb7pLOy2pf"^^com.spotify:song("7 rings (feat. 2 Chainz) - Remix"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:17lzZA2AlOHwCwFALHttmp"^^com.spotify:artist("2 Chainz")] }
-C: ]];
-C: now => (@com.spotify.song()), contains(artists, "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")) => notify
-C: #[results=[
-C:   { id="spotify:track:2qT1uLXPVPzGgFOx4jtEuo"^^com.spotify:song("no tears left to cry"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2018-08-17T00:00:00.000Z"), popularity=81, energy=71, danceability=69 },
-C:   { id="spotify:track:3e9HZxeyfWwjeyPAMmWSSQ"^^com.spotify:song("thank u, next"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=84, energy=65, danceability=71 },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=86, energy=31, danceability=77 },
-C:   { id="spotify:track:6va6SjWz457IOZidBppAhz"^^com.spotify:song("7 rings - live"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-12-23T00:00:00.000Z"), popularity=54, energy=73, danceability=44 },
-C:   { id="spotify:track:6AyI8UGx8Y4peb7pLOy2pf"^^com.spotify:song("7 rings (feat. 2 Chainz) - Remix"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:17lzZA2AlOHwCwFALHttmp"^^com.spotify:artist("2 Chainz")], release_date=new Date("2019-02-01T00:00:00.000Z"), popularity=52, energy=34, danceability=78 },
-C:   { id="spotify:track:4HBZA5flZLE435QTztThqH"^^com.spotify:song("Stuck with U (with Justin Bieber)"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:1uNFoZAHBGtllmzznpCI3s"^^com.spotify:artist("Justin Bieber")], release_date=new Date("2020-05-08T00:00:00.000Z"), popularity=93, energy=45, danceability=59 },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=86, energy=31, danceability=77 },
-C:   { id="spotify:track:0Ryd8975WihbObpp5cPW1t"^^com.spotify:song("boyfriend (with Social House)"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:5UjifI1TYefXWn9GdqDOHl"^^com.spotify:artist("Social House")], release_date=new Date("2019-08-02T00:00:00.000Z"), popularity=81, energy=79, danceability=4 },
-C:   { id="spotify:track:4kV4N9D1iKVxx1KLvtTpjS"^^com.spotify:song("break up with your girlfriend, i'm bored"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=80, energy=55, danceability=72 },
-C:   { id="spotify:track:5OCJzvD7sykQEKHH7qAC3C"^^com.spotify:song("God is a woman"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2018-08-17T00:00:00.000Z"), popularity=79, energy=65, danceability=60 }
-C: ]]
-C: #[count=25];
-A: i found stuck with u(with justin bieber), no tears left to cry, and thank u, next . would you like more songs ?
-AT: $dialogue @org.thingpedia.dialogue.transaction.learn_more;
-U: no . out of those 3 songs which one is the most popular ?
-UT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-UT: now => (sort popularity desc of (@com.spotify.song())), contains(artists, "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")) => notify;
-C: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-C: now => [artists] of ((@com.spotify.song()), id =~ "7 rings") => notify
-C: #[results=[
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:0YEg2JfkMeJ1hTYqop4A5o"^^com.spotify:song("7 Rings"), artists=["spotify:artist:00YTqRClk82aMchQQpYMd5"^^com.spotify:artist("Our Last Night"), "spotify:artist:4gO25bbcu1eFNi8uDCvJFS"^^com.spotify:artist("Derek DiScanio")] },
-C:   { id="spotify:track:2fOmk4x4OJZsjK60kjW7KZ"^^com.spotify:song("7 Rings"), artists=["spotify:artist:1Vvvx45Apu6dQqwuZQxtgW"^^com.spotify:artist("Kidz Bop Kids")] },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:6va6SjWz457IOZidBppAhz"^^com.spotify:song("7 rings - live"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")] },
-C:   { id="spotify:track:6AyI8UGx8Y4peb7pLOy2pf"^^com.spotify:song("7 rings (feat. 2 Chainz) - Remix"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:17lzZA2AlOHwCwFALHttmp"^^com.spotify:artist("2 Chainz")] }
-C: ]];
-C: now => (@com.spotify.song()), contains(artists, "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")) => notify
-C: #[results=[
-C:   { id="spotify:track:2qT1uLXPVPzGgFOx4jtEuo"^^com.spotify:song("no tears left to cry"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2018-08-17T00:00:00.000Z"), popularity=81, energy=71, danceability=69 },
-C:   { id="spotify:track:3e9HZxeyfWwjeyPAMmWSSQ"^^com.spotify:song("thank u, next"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=84, energy=65, danceability=71 },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=86, energy=31, danceability=77 },
-C:   { id="spotify:track:6va6SjWz457IOZidBppAhz"^^com.spotify:song("7 rings - live"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-12-23T00:00:00.000Z"), popularity=54, energy=73, danceability=44 },
-C:   { id="spotify:track:6AyI8UGx8Y4peb7pLOy2pf"^^com.spotify:song("7 rings (feat. 2 Chainz) - Remix"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:17lzZA2AlOHwCwFALHttmp"^^com.spotify:artist("2 Chainz")], release_date=new Date("2019-02-01T00:00:00.000Z"), popularity=52, energy=34, danceability=78 },
-C:   { id="spotify:track:4HBZA5flZLE435QTztThqH"^^com.spotify:song("Stuck with U (with Justin Bieber)"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:1uNFoZAHBGtllmzznpCI3s"^^com.spotify:artist("Justin Bieber")], release_date=new Date("2020-05-08T00:00:00.000Z"), popularity=93, energy=45, danceability=59 },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=86, energy=31, danceability=77 },
-C:   { id="spotify:track:0Ryd8975WihbObpp5cPW1t"^^com.spotify:song("boyfriend (with Social House)"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:5UjifI1TYefXWn9GdqDOHl"^^com.spotify:artist("Social House")], release_date=new Date("2019-08-02T00:00:00.000Z"), popularity=81, energy=79, danceability=4 },
-C:   { id="spotify:track:4kV4N9D1iKVxx1KLvtTpjS"^^com.spotify:song("break up with your girlfriend, i'm bored"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=80, energy=55, danceability=72 },
-C:   { id="spotify:track:5OCJzvD7sykQEKHH7qAC3C"^^com.spotify:song("God is a woman"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2018-08-17T00:00:00.000Z"), popularity=79, energy=65, danceability=60 }
-C: ]]
-C: #[count=25];
-C: now => (sort popularity desc of (@com.spotify.song())), contains(artists, "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")) => notify
-C: #[results=[
-C:   { id="spotify:track:4HBZA5flZLE435QTztThqH"^^com.spotify:song("Stuck with U (with Justin Bieber)"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:1uNFoZAHBGtllmzznpCI3s"^^com.spotify:artist("Justin Bieber")], release_date=new Date("2020-05-08T00:00:00.000Z"), popularity=93, energy=45, danceability=59 },
-C:   { id="spotify:track:24ySl2hOPGCDcxBxFIqWBu"^^com.spotify:song("Rain On Me (with Ariana Grande)"), artists=["spotify:artist:1HY2Jd0NmPuamShAr6KMms"^^com.spotify:artist("Lady Gaga"), "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2020-05-22T00:00:00.000Z"), popularity=93, energy=85, danceability=67 },
-C:   { id="spotify:track:4HBZA5flZLE435QTztThqH"^^com.spotify:song("Stuck with U (with Justin Bieber)"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:1uNFoZAHBGtllmzznpCI3s"^^com.spotify:artist("Justin Bieber")], release_date=new Date("2020-05-08T00:00:00.000Z"), popularity=93, energy=45, danceability=59 },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=86, energy=31, danceability=77 },
-C:   { id="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=86, energy=31, danceability=77 },
-C:   { id="spotify:track:3e9HZxeyfWwjeyPAMmWSSQ"^^com.spotify:song("thank u, next"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=84, energy=65, danceability=71 },
-C:   { id="spotify:track:0Ryd8975WihbObpp5cPW1t"^^com.spotify:song("boyfriend (with Social House)"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande"), "spotify:artist:5UjifI1TYefXWn9GdqDOHl"^^com.spotify:artist("Social House")], release_date=new Date("2019-08-02T00:00:00.000Z"), popularity=81, energy=79, danceability=4 },
-C:   { id="spotify:track:2qT1uLXPVPzGgFOx4jtEuo"^^com.spotify:song("no tears left to cry"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2018-08-17T00:00:00.000Z"), popularity=81, energy=71, danceability=69 },
-C:   { id="spotify:track:4kV4N9D1iKVxx1KLvtTpjS"^^com.spotify:song("break up with your girlfriend, i'm bored"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2019-02-08T00:00:00.000Z"), popularity=80, energy=55, danceability=72 },
-C:   { id="spotify:track:5OCJzvD7sykQEKHH7qAC3C"^^com.spotify:song("God is a woman"), artists=["spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")], release_date=new Date("2018-08-17T00:00:00.000Z"), popularity=79, energy=65, danceability=60 }
-C: ]]
-C: #[count=25];
-A: stuck with u(with justin bieber) is the most popular . is there anything else i can help you with ?
-AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-U: nope, bye .
-UT: $dialogue @org.thingpedia.dialogue.transaction.cancel;
-====
 # snips-nlu/spotify-3
 U: play the Música Da Série De Filmes O Hobbit album by Alex Otaola
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
@@ -234,7 +17,7 @@ UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jer
 # snips-nlu/spotify-10
 U: play the newest by Exuma
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("exuma")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("exuma"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-11
 U: Play the album alas y raíces by Dave Pybus .
@@ -254,7 +37,7 @@ UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("ron
 # snips-nlu/spotify-16
 U: Play the best music by Arthur Johnston .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("arthur johnston")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("arthur johnston"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-17
 U: Play the song gangsta? by Siavash Ghomayshi
@@ -294,12 +77,12 @@ UT: now => (@com.spotify.album(), id =~ "alone, again" && contains(artists, null
 # snips-nlu/spotify-43
 U: Please play the newest music by Evil Jared Hasselhoff
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("evil jared hasselhoff")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("evil jared hasselhoff"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-46
 U: Can you play a top 5 song by Manos Hadjidakis
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("manos hadjidakis")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("manos hadjidakis"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-48
 U: Play music by Antonella Barba from the album Bath
@@ -339,7 +122,7 @@ UT: now => (@com.spotify.artist(), id =~ "Ashley")[1] => @com.spotify.play_artis
 # snips-nlu/spotify-85
 U: play Miguelito top charting album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("miguelito")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("miguelito"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-89
 U: play songs by Wise
@@ -359,7 +142,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("spac
 # snips-nlu/spotify-99
 U: Find me music by Kaori Utatsuki off the album that has top-twenty hits
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("kaori utatsuki")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("kaori utatsuki"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-101
 U: Play some thrash metal .
@@ -429,7 +212,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("siss
 # snips-nlu/spotify-153
 U: I want to hear Sarban's greatest hits
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sarban")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("sarban"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-159
 U: Play Ciribiribin by Sandeep Khare
@@ -439,7 +222,7 @@ UT: now => (@com.spotify.song(), id =~ "ciribiribin" && contains(artists, null^^
 # snips-nlu/spotify-163
 U: Play the top 5 by Akira The Don .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("akira the don")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("akira the don"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-166
 U: play The Necromancer
@@ -564,7 +347,7 @@ UT: now => @com.spotify.song(), contains~(genres, "salsa") => @com.spotify.play_
 # snips-nlu/spotify-228
 U: Play top Rosanne Cash
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("rosanne cash")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("rosanne cash"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-231
 U: Play Midnight Special
@@ -594,7 +377,7 @@ UT: now => (@com.spotify.song(), id =~ "martha my dear" && contains(artists, nul
 # snips-nlu/spotify-248
 U: play the greatest Adrian Kowanek music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("adrian kowanek")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("adrian kowanek"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-250
 U: I'd like to listen to Space music
@@ -604,7 +387,7 @@ UT: now => @com.spotify.song(), contains~(genres, "space") => @com.spotify.play_
 # snips-nlu/spotify-251
 U: play the last Niney The Observer song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("niney the observer")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("niney the observer"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-253
 U: Play industrial music.
@@ -624,12 +407,12 @@ UT: now => (@com.spotify.song(), id =~ "she came in through the bathroom window"
 # snips-nlu/spotify-265
 U: play some best selling rave songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(genres, "rave") => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains~(genres, "rave")) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-267
 U: Play the newest stuff by blowfly
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("blowfly")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("blowfly"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-273
 U: play Clifford Brown All Stars by Michael Balzary
@@ -659,7 +442,7 @@ UT: now => (@com.spotify.album(), id =~ "this is the day" && contains(artists, n
 # snips-nlu/spotify-281
 U: Play a new tune by louis silvers .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("louis silvers")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("louis silvers"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-282
 U: Play me a song by Steve Hackett from Manuel
@@ -674,7 +457,7 @@ UT: now => (@com.spotify.song(), id =~ "my tribute" && contains(artists, null^^c
 # snips-nlu/spotify-295
 U: Play the newest music by Gladys Knight
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gladys knight")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("gladys knight"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-296
 U: play Hora Din Moldova by Yamazaki Maso
@@ -714,7 +497,7 @@ UT: now => @com.spotify.song(), contains~(genres, "fun-punk") => @com.spotify.pl
 # snips-nlu/spotify-325
 U: I want to hear popular music from Martin Lopez
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("martin lopez")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("martin lopez"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-330
 U: Play Lorenzo Palacios Quispe
@@ -749,7 +532,7 @@ UT: now => (@com.spotify.album(), id =~ "luxury liner")[1] => @com.spotify.play_
 # snips-nlu/spotify-352
 U: Please play good music by Will Oldham .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("will oldham")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("will oldham"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-354
 U: play Vanlose Stairway by Janove Ottesen
@@ -759,7 +542,7 @@ UT: now => (@com.spotify.song(), id =~ "vanlose stairway" && contains(artists, n
 # snips-nlu/spotify-356
 U: Play music from the top-5 from artist Kenia Arias
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("kenia arias")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("kenia arias"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-358
 U: Play some bass music.
@@ -784,7 +567,7 @@ UT: now => (@com.spotify.artist(), id =~ "Robbie Merrill")[1] => @com.spotify.pl
 # snips-nlu/spotify-390
 U: Play new music from Liang Wern Fook
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("liang wern fook")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("liang wern fook"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-392
 U: play By The Sleepy Lagoon by Greg Kurstin
@@ -824,7 +607,7 @@ UT: now => (@com.spotify.song(), id =~ "all of your toys" && contains(artists, n
 # snips-nlu/spotify-412
 U: Play music by Fidel Nadal sorted by newest .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fidel nadal")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("fidel nadal"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-415
 U: Play Dave Wyndorf album
@@ -874,7 +657,7 @@ UT: now => @com.spotify.song(), contains~(genres, "rumba africana") => @com.spot
 # snips-nlu/spotify-440
 U: Play a top-five song by Pete Candoli .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("pete candoli")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("pete candoli"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-443
 U: Can you play me some Pop-folk music
@@ -894,7 +677,7 @@ UT: now => (@com.spotify.album(), id =~ "insult to injury" && contains(artists, 
 # snips-nlu/spotify-457
 U: play latest Shaggy music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("shaggy")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("shaggy"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-463
 U: Play That Would Be Something by Eden Ahbez
@@ -934,7 +717,7 @@ UT: now => @com.spotify.song(), contains~(genres, "new wave of american heavy me
 # snips-nlu/spotify-474
 U: Play me the best Charles Neidich song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("charles neidich")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("charles neidich"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-481
 U: Play the Ricky Wilson album Spectral Dusk
@@ -994,12 +777,12 @@ UT: now => (@com.spotify.song(), id =~ "maggot brain" && contains(artists, null^
 # snips-nlu/spotify-508
 U: I want to hear the top Tim Madison
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tim madison")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("tim madison"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-510
 U: Play the best songs by Jes Brieden
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jes brieden")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jes brieden"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-511
 U: Play me a song by Kevin Cadogan
@@ -1034,12 +817,12 @@ UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("br
 # snips-nlu/spotify-526
 U: play the top five songs by Isaac Hayes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("isaac hayes")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("isaac hayes"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-530
 U: Play top 20 from frank farian
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("frank farian")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("frank farian"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-532
 U: Play some psychadelic music.
@@ -1079,7 +862,7 @@ UT: now => (@com.spotify.album(), id =~ "kings of the wild frontier" && contains
 # snips-nlu/spotify-555
 U: Play Bob Hilliard top-twenty music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bob hilliard")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("bob hilliard"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-559
 U: I want to hear Techno-industrial music.
@@ -1124,7 +907,7 @@ UT: now => @com.spotify.song(), contains~(genres, "louisiana blues") => @com.spo
 # snips-nlu/spotify-584
 U: Play new Ian Mclagan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ian mclagan")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("ian mclagan"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-588
 U: Play Before I Grew Up To Love You by Wafah Dufour
@@ -1139,7 +922,7 @@ UT: now => (@com.spotify.song(), id =~ "fight on, state")[1] => @com.spotify.pla
 # snips-nlu/spotify-595
 U: Play the top five Cemil Bey songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("cemil bey")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("cemil bey"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-597
 U: play music by Francis Healy
@@ -1149,7 +932,7 @@ UT: now => (@com.spotify.artist(), id =~ "Francis Healy")[1] => @com.spotify.pla
 # snips-nlu/spotify-603
 U: Play Rei Momo newest album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (sort release_date desc of @com.spotify.album(), id =~ "rei momo")[1] => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), id =~ "rei momo"))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-608
 U: Play Punk Rock music
@@ -1199,7 +982,7 @@ UT: now => (@com.spotify.song(), id =~ "alles heeft ritme" && contains(artists, 
 # snips-nlu/spotify-624
 U: Play the best Vanessa Peters songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("vanessa peters")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("vanessa peters"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-625
 U: Play That Stubborn Kinda Fellow by Michael Amott
@@ -1224,7 +1007,7 @@ UT: now => @com.spotify.song(), contains~(genres, "christian gangsta rap") => @c
 # snips-nlu/spotify-641
 U: play the most popular Miles Jones track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("miles jones")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("miles jones"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-644
 U: Play slow rock music
@@ -1244,12 +1027,12 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("adam
 # snips-nlu/spotify-657
 U: Play a popular Gurdas Maan track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gurdas maan")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("gurdas maan"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-660
 U: Play the top-20 music by merz
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("merz")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("merz"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-662
 U: Play a Mike Osborne song
@@ -1309,12 +1092,12 @@ UT: now => (@com.spotify.song(), id =~ "in every dream home a heartache" && cont
 # snips-nlu/spotify-704
 U: Play the best song by Henry Rollins .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("henry rollins")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("henry rollins"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-715
 U: play the last track by Shavo Odadjian
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("shavo odadjian")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("shavo odadjian"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-716
 U: Play Brotherhood by Ock Joo-hyun
@@ -1324,7 +1107,7 @@ UT: now => (@com.spotify.album(), id =~ "brotherhood" && contains(artists, null^
 # snips-nlu/spotify-717
 U: play latest George Ducas music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("george ducas")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("george ducas"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-719
 U: play I Could Write A Book
@@ -1359,7 +1142,7 @@ UT: now => (@com.spotify.song(), id =~ "her majesty")[1] => @com.spotify.play_so
 # snips-nlu/spotify-748
 U: I want to hear the newest music from The Railway Children
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("the railway children")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("the railway children"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-750
 U: I want to hear Vegetables by pharrell williams
@@ -1414,7 +1197,7 @@ UT: now => (@com.spotify.song(), id =~ "faget")[1] => @com.spotify.play_song(son
 # snips-nlu/spotify-775
 U: Play the top song by Jack Grisham
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jack grisham")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jack grisham"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-776
 U: Please play Jag Vill Leva I Europa by porta
@@ -1485,7 +1268,7 @@ UT: now => (@com.spotify.song(), id =~ "on my own")[1] => @com.spotify.play_song
 # snips-nlu/spotify-816
 U: Play Nick Hexum latest album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("nick hexum")) => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("nick hexum"))))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-819
 U: Play the sound track by Ferry Corsten
@@ -1565,7 +1348,7 @@ UT: now => (@com.spotify.song(), id =~ "there must be more to life than this")[1
 # snips-nlu/spotify-862
 U: Play the new music from Wilko Johnson
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("wilko johnson")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("wilko johnson"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-865
 U: Play the album Shooting Silvio by Dave Sabo
@@ -1580,7 +1363,7 @@ UT: now => (@com.spotify.album(), id =~ "seaside" && contains(artists, null^^com
 # snips-nlu/spotify-878
 U: play top tunes by Joseph Utsler
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("joseph utsler")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("joseph utsler"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-879
 U: play southern rock tunes
@@ -1605,7 +1388,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("bust
 # snips-nlu/spotify-890
 U: I want to hear the top 5 Jamie Lidell songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jamie lidell")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jamie lidell"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-893
 U: play Wolves by Larry Gatlin
@@ -1630,7 +1413,7 @@ UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("mau
 # snips-nlu/spotify-900
 U: Play the newest Phil Stacey .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("phil stacey")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("phil stacey"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-909
 U: Play a song off the Nicht Sprechen album
@@ -1650,7 +1433,7 @@ UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("wel
 # snips-nlu/spotify-923
 U: Play the latest Joan Baez .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("joan baez")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("joan baez"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-924
 U: Play the album Qr Iii by bobby bare
@@ -1670,7 +1453,7 @@ UT: now => (@com.spotify.song(), id =~ "cry baby cry" && contains(artists, null^
 # snips-nlu/spotify-929
 U: play a top-twenty tune by Noor Jehan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("noor jehan")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("noor jehan"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-931
 U: Do you have something like Impossible Is Nothing by Abderrahmane Abdelli?
@@ -1706,7 +1489,7 @@ UT: now => (@com.spotify.song(), id =~ "tanti auguri a te" && contains(artists, 
 U: play the greatest james yorkston song
 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("james yorkston")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("james yorkston"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-957
 U: I want to hear the Live At Slane Castle album by Haifa Wehbe
@@ -1721,7 +1504,7 @@ UT: now => (@com.spotify.artist(), id =~ "Dick Marx")[1] => @com.spotify.play_ar
 # snips-nlu/spotify-963
 U: Play Anweshaa by the new first.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("anweshaa")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("anweshaa"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-971
 U: Play sugar baby by frank beard
@@ -1766,7 +1549,7 @@ UT: now => @com.spotify.song(), contains~(genres, "art punk") => @com.spotify.pl
 # snips-nlu/spotify-1000
 U: Play me the most popular Arthur Johnston song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("arthur johnston")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("arthur johnston"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1002
 U: play Tonight Only! by Nastya Kamenskih
@@ -1796,7 +1579,7 @@ UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("ma
 # snips-nlu/spotify-1024
 U: Play me the greatest Howard Levy song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("howard levy")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("howard levy"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1037
 U: Play some new age music
@@ -1806,7 +1589,7 @@ UT: now => @com.spotify.song(), contains~(genres, "new age") => @com.spotify.pla
 # snips-nlu/spotify-1038
 U: I want to hear any top five music from Gene Autry
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gene autry")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("gene autry"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1039
 U: play music by Vybz Kartel
@@ -1816,7 +1599,7 @@ UT: now => (@com.spotify.artist(), id =~ "Vybz Kartel")[1] => @com.spotify.play_
 # snips-nlu/spotify-1040
 U: Can I hear the latest music from Bahar Kizil?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bahar kizil")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("bahar kizil"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1042
 U: Play Humour
@@ -1826,12 +1609,12 @@ UT: now => @com.spotify.song(), contains~(genres, "humour") => @com.spotify.play
 # snips-nlu/spotify-1052
 U: Play the top-twenty from Alexander Braginsky .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("alexander braginsky")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("alexander braginsky"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1055
 U: Play the top 10 by Sankha Chatterjee .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sankha chatterjee")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("sankha chatterjee"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1056
 U: Play music by Nick La Rocca
@@ -1881,7 +1664,7 @@ UT: now => (@com.spotify.artist(), id =~ "Miss Platnum")[1] => @com.spotify.play
 # snips-nlu/spotify-1087
 U: play Christina Milian latest music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("christina milian")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("christina milian"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1094
 U: Play Richard Fortus' Live Collection .
@@ -1951,7 +1734,7 @@ UT: now => (@com.spotify.artist(), id =~ "Sivamani")[1] => @com.spotify.play_art
 # snips-nlu/spotify-1133
 U: Can you play the greatest sarah brightman song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sarah brightman")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("sarah brightman"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1136
 U: play the song Shine A Light
@@ -1966,7 +1749,7 @@ UT: now => (@com.spotify.artist(), id =~ "Frankie Laine")[1] => @com.spotify.pla
 # snips-nlu/spotify-1148
 U: play the top five songs by Gad Elbaz
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gad elbaz")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("gad elbaz"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1153
 U: play Fill Yourself With Music by Ray Manzarek
@@ -1991,12 +1774,12 @@ UT: now => @com.spotify.song(), contains~(genres, "chanson") => @com.spotify.pla
 # snips-nlu/spotify-1163
 U: Play the latest music by Martin Luther Mccoy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("martin luther mccoy")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("martin luther mccoy"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1169
 U: play the top twenty tracks of Ron Jarzombek
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ron jarzombek")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("ron jarzombek"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1171
 U: Play me a tune by john clayton
@@ -2016,7 +1799,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("larr
 # snips-nlu/spotify-1178
 U: play Roland Alphonso tunes that are most popular
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("roland alphonso")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("roland alphonso"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1179
 U: Play Ramakadha by Karl Davydov please
@@ -2091,7 +1874,7 @@ UT: now => (@com.spotify.album(), id =~ "these four walls" && contains(artists, 
 # snips-nlu/spotify-1225
 U: Can I listen to Dj Vibe's top 10?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("dj vibe")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("dj vibe"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1227
 U: Lets hear some booty bass
@@ -2121,7 +1904,7 @@ UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("shi
 # snips-nlu/spotify-1253
 U: Play me a popular song by Koichi Domoto
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("koichi domoto")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("koichi domoto"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1254
 U: Play Saturday Nights & Sunday Mornings
@@ -2156,12 +1939,12 @@ UT: now => (@com.spotify.artist(), id =~ "Raheem Devaughn")[1] => @com.spotify.p
 # snips-nlu/spotify-1277
 U: Play the top caleigh peters .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("caleigh peters")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("caleigh peters"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1278
 U: Play new Teo Macero
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("teo macero")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("teo macero"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1285
 U: I want to listen to Merrily We Roll Along by Marko Desantis .
@@ -2181,7 +1964,7 @@ UT: now => (@com.spotify.song(), id =~ "mister music man" && contains(artists, n
 # snips-nlu/spotify-1290
 U: Let me hear the top album by the artist, Skin .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("skin")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("skin"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1291
 U: Play Harel Skaat
@@ -2211,7 +1994,7 @@ UT: now => @com.spotify.song(), contains~(genres, "britpop") => @com.spotify.pla
 # snips-nlu/spotify-1319
 U: Play top-50 Peter Frampton songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("peter frampton")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("peter frampton"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1323
 U: play Tom Baxter tracks
@@ -2231,7 +2014,7 @@ UT: now => (@com.spotify.song(), id =~ "september, gouden roos" && contains(arti
 # snips-nlu/spotify-1339
 U: Please anything good by Chieko Ochi
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("chieko ochi")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("chieko ochi"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1341
 U: Play Apbl98 by Alden Penner .
@@ -2256,12 +2039,12 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("saki
 # snips-nlu/spotify-1353
 U: Play a top track by Janamanchi Seshadri Sarma
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("janamanchi seshadri sarma")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("janamanchi seshadri sarma"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1355
 U: Play music by Sha Money Xl sort by good .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sha money xl")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("sha money xl"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1357
 U: Play Someday Soon by fiona
@@ -2276,7 +2059,7 @@ UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("tu
 # snips-nlu/spotify-1361
 U: Play a top twenty sort by Akinyele .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("akinyele")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("akinyele"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1368
 U: Play Rob Mills album The Golden Archipelago .
@@ -2316,7 +2099,7 @@ UT: now => (@com.spotify.album(), id =~ "step up your game" && contains(artists,
 # snips-nlu/spotify-1390
 U: Play the top five songs from Robert Lockwood Junior .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("robert lockwood junior")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("robert lockwood junior"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1391
 U: Play some latin music.
@@ -2386,7 +2169,7 @@ UT: now => (@com.spotify.artist(), id =~ "Dave Joyal")[1] => @com.spotify.play_a
 # snips-nlu/spotify-1422
 U: I want to hear something from the top-fifty by Jose Pasillas
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jose pasillas")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jose pasillas"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1426
 U: play primus 
@@ -2406,7 +2189,7 @@ UT: now => (@com.spotify.artist(), id =~ "Bill Evans")[1] => @com.spotify.play_a
 # snips-nlu/spotify-1436
 U: Can you play the greatest songs by Mauro Picotto
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("mauro picotto")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("mauro picotto"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1437
 U: Play music by Deenanath Mangeshkar
@@ -2426,7 +2209,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("vert
 # snips-nlu/spotify-1444
 U: Play the most popular stuff by Tina Dico
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tina dico")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("tina dico"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1450
 U: Can you play some music from my road trip album
@@ -2496,7 +2279,7 @@ UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("jo
 # snips-nlu/spotify-1495
 U: list to the most popular Muireann Nic Amhlaoibh song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("muireann nic amhlaoibh")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("muireann nic amhlaoibh"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1500
 U: Play the song Long Live Love
@@ -2506,7 +2289,7 @@ UT: now => (@com.spotify.song(), id =~ "long live love")[1] => @com.spotify.play
 # snips-nlu/spotify-1502
 U: Play the top of emil de cou
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("emil de cou")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("emil de cou"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1509
 U: Play instrumental pop
@@ -2531,7 +2314,7 @@ UT: now => (@com.spotify.artist(), id =~ "Rodney Whitaker")[1] => @com.spotify.p
 # snips-nlu/spotify-1519
 U: play the latest Thelma Aoyama
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("thelma aoyama")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("thelma aoyama"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1520
 U: Play some music by Karl Blau .
@@ -2551,12 +2334,12 @@ UT: now => (@com.spotify.artist(), id =~ "mark ashley")[1] => @com.spotify.play_
 # snips-nlu/spotify-1542
 U: Play the top Maynard James Keenan .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("maynard james keenan")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("maynard james keenan"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1544
 U: Play the most popular song by espen lind
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("espen lind")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("espen lind"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1545
 U: Play Yuauea by Rick Ross
@@ -2636,7 +2419,7 @@ UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("daw
 # snips-nlu/spotify-1592
 U: play newest Robert Palmer sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("robert palmer")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("robert palmer"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1595
 U: Play some Dj Qbert .
@@ -2726,7 +2509,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("nash
 # snips-nlu/spotify-1666
 U: play the best Elizaveta Khripounova
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("elizaveta khripounova")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("elizaveta khripounova"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1669
 U: Play Crazy=genius by The Alchemist
@@ -2796,7 +2579,7 @@ UT: now => (@com.spotify.artist(), id =~ "Lenny Kaye")[1] => @com.spotify.play_a
 # snips-nlu/spotify-1721
 U: play Ngola Ritmos top-ten songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ngola ritmos")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("ngola ritmos"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1725
 U: Play the album Cara De Dios .
@@ -2836,7 +2619,7 @@ UT: now => (@com.spotify.artist(), id =~ "Angelo Amorevoli")[1] => @com.spotify.
 # snips-nlu/spotify-1740
 U: Play artist Vlada Divljan from something he did that is good
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("vlada divljan")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("vlada divljan"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1741
 U: Play the track Pocahontas John Farnham
@@ -2846,7 +2629,7 @@ UT: now => (@com.spotify.song(), id =~ "pocahontas" && contains(artists, null^^c
 # snips-nlu/spotify-1742
 U: play some popular bryan gregory songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bryan gregory")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("bryan gregory"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1747
 U: Play some Techno
@@ -2856,7 +2639,7 @@ UT: now => @com.spotify.song(), contains~(genres, "techno") => @com.spotify.play
 # snips-nlu/spotify-1749
 U: play Fereydoun Farrokhzad best track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fereydoun farrokhzad")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("fereydoun farrokhzad"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1750
 U: Can I listen to music from the Easy Listening genre?
@@ -2866,7 +2649,7 @@ UT: now => @com.spotify.song(), contains~(genres, "easy listening") => @com.spot
 # snips-nlu/spotify-1752
 U: play the top-20 Rita Macneil songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("rita macneil")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("rita macneil"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1755
 U: Play a sound track by Mac Dre .
@@ -2876,12 +2659,12 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mac 
 # snips-nlu/spotify-1759
 U: Play the best music from Klaus Badelt .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("klaus badelt")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("klaus badelt"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1766
 U: I'd like to hear the last song fro Willa Ford .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("willa ford")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("willa ford"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1771
 U: play Techno music
@@ -2986,22 +2769,22 @@ UT: now => (@com.spotify.song(), id =~ "domino" && contains(artists, null^^com.s
 # snips-nlu/spotify-1842
 U: play the newest Martin Solveig sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("martin solveig")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("martin solveig"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1845
 U: play Mohammed Abdu from top 20
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("mohammed abdu")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("mohammed abdu"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1846
 U: Play the top ten by Andrea Del Rosario .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("andrea del rosario")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("andrea del rosario"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1854
 U: Play rie fu music sorted by the best .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("rie fu")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("rie fu"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1860
 U: play steve harris False Gestures For A Devious Public album
@@ -3011,7 +2794,7 @@ UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("st
 # snips-nlu/spotify-1862
 U: I want to hear a good album from Toni Cottura .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("toni cottura")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("toni cottura"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1870
 U: I need some Hardcore Hip Hop
@@ -3021,7 +2804,7 @@ UT: now => @com.spotify.song(), contains~(genres, "hardcore hip hop") => @com.sp
 # snips-nlu/spotify-1874
 U: play Dj Ozma top songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("dj ozma")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("dj ozma"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1875
 U: PLay a track by deeyah khan .
@@ -3041,7 +2824,7 @@ UT: now => (@com.spotify.song(), id =~ "two suns in the sunset" && contains(arti
 # snips-nlu/spotify-1886
 U: Play the greatest music by Phoebe Snow
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("phoebe snow")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("phoebe snow"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1896
 U: Play music off the track Child Maurice
@@ -3066,7 +2849,7 @@ UT: now => @com.spotify.song(), contains~(genres, "ambient") => @com.spotify.pla
 # snips-nlu/spotify-1911
 U: Play the last song by Goldie
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("goldie")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("goldie"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1912
 U: Play Pride Of The Prairie from Johnny Burke
@@ -3081,7 +2864,7 @@ UT: now => (@com.spotify.song(), id =~ "le renouveau")[1] => @com.spotify.play_s
 # snips-nlu/spotify-1916
 U: play the latest Thelma Aoyama
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("thelma aoyama")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("thelma aoyama"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1922
 U: I would like to hear a song by Tim Reynolds
@@ -3091,7 +2874,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("tim 
 # snips-nlu/spotify-1928
 U: Play me Benjamin Kowalewicz's top hits
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("benjamin kowalewicz")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("benjamin kowalewicz"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1930
 U: Play some music by Mark Heard .
@@ -3151,12 +2934,12 @@ UT: now => (@com.spotify.album(), id =~ "the music of nature" && contains(artist
 # snips-nlu/spotify-1957
 U: Play the music of Aphex Twin's good Album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("aphex twin")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("aphex twin"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1967
 U: Play the last Jonny Wickersham song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jonny wickersham")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jonny wickersham"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1971
 U: Play Hættuleg Hljómsveit & Glæpakvendið Stella by Kaori Iida
@@ -3191,7 +2974,7 @@ UT: now => (@com.spotify.album(), id =~ "turbulence wild streetdanz" && contains
 # snips-nlu/spotify-1987
 U: Play the greatest Ricky Bell music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ricky bell")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("ricky bell"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1989
 U: Play music by Sarah Connor
@@ -3211,7 +2994,7 @@ UT: now => (@com.spotify.song(), id =~ "odessa" && contains(artists, null^^com.s
 # snips-nlu/spotify-1995
 U: Play the most popular track from Valery Alexandrovich Kipelov
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("valery alexandrovich kipelov")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("valery alexandrovich kipelov"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1999
 U: play Roy Orbison tunes now
@@ -3221,7 +3004,7 @@ UT: now => (@com.spotify.artist(), id =~ "Roy Orbison")[1] => @com.spotify.play_
 # snips-nlu/spotify-2003
 U: is there something new you can play by Lola Monroe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("lola monroe")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("lola monroe"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2004
 U: I want to hear something from Post-punk Revival
@@ -3231,7 +3014,7 @@ UT: now => @com.spotify.song(), contains~(genres, "post-punk revival") => @com.s
 # snips-nlu/spotify-2007
 U: Play the top music from Epic Mazur .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("epic mazur")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("epic mazur"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2008
 U: I want to hear track 34 .
@@ -3256,7 +3039,7 @@ UT: now => (@com.spotify.artist(), id =~ "Hridaynath Mangeshkar")[1] => @com.spo
 # snips-nlu/spotify-2023
 U: Let me hear Wintley Phipps top fifty album .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("wintley phipps")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("wintley phipps"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-2025
 U: play me some Dom Pachino
@@ -3311,7 +3094,7 @@ UT: now => (@com.spotify.artist(), id =~ "Timour Moutsouraev")[1] => @com.spotif
 # snips-nlu/spotify-2050
 U: most popular song of taco ockerse
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("taco ockerse")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("taco ockerse"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2051
 U: Play Tennessee Saturday Night by Mr. Porter
@@ -3321,7 +3104,7 @@ UT: now => (@com.spotify.song(), id =~ "tennessee saturday night" && contains(ar
 # snips-nlu/spotify-2055
 U: I want to hear the last album from Frank Iero
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("frank iero")) => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("frank iero"))))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-2059
 U: Can you play some music by Abatte Barihun?
@@ -3336,7 +3119,7 @@ UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("sh
 # snips-nlu/spotify-2062
 U: play something new by tansen
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tansen")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("tansen"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2066
 U: Play some Grand Puba .
@@ -3346,7 +3129,7 @@ UT: now => (@com.spotify.artist(), id =~ "Grand Puba")[1] => @com.spotify.play_a
 # snips-nlu/spotify-2067
 U: Play the top fifty by Kate Bush .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("kate bush")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("kate bush"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2068
 U: Play the Stephen Stills album Verge
@@ -3386,7 +3169,7 @@ UT: now => (@com.spotify.song(), id =~ "say it again" && contains(artists, null^
 # snips-nlu/spotify-2079
 U: I want to hear music from the top fifty by Yasuhiko Fukuda
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("yasuhiko fukuda")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("yasuhiko fukuda"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2082
 U: I'd like to listen to mark rae
@@ -3416,12 +3199,12 @@ UT: now => (@com.spotify.artist(), id =~ "G. V. Prakash Kumar")[1] => @com.spoti
 # snips-nlu/spotify-2107
 U: can i lesten to the latest album of T-bone Burnett
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("t-bone burnett")) => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("t-bone burnett"))))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-2109
 U: Play some good music from Jamelia .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jamelia")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jamelia"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2110
 U: Play Alabama Concerto by Kou Shibasaki .
@@ -3431,12 +3214,12 @@ UT: now => (@com.spotify.album(), id =~ "alabama concerto" && contains(artists, 
 # snips-nlu/spotify-2114
 U: Let's listen to the best from Jeff Loomis .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jeff loomis")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jeff loomis"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2119
 U: I want to hear Nellie Mckay's new music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("nellie mckay")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("nellie mckay"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2120
 U: Play Moris Tepper
@@ -3446,7 +3229,7 @@ UT: now => (@com.spotify.artist(), id =~ "Moris Tepper")[1] => @com.spotify.play
 # snips-nlu/spotify-2124
 U: Play Maria Severa Onofriana and sort by most popular .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("maria severa onofriana")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("maria severa onofriana"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2127
 U: Play Too Much Rain by the artist D-loc .
@@ -3476,7 +3259,7 @@ UT: now => (@com.spotify.song(), id =~ "ashita e" && contains(artists, null^^com
 # snips-nlu/spotify-2139
 U: Play the top-5 track from Boris Liatochinski .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("boris liatochinski")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("boris liatochinski"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2145
 U: Play some fun-punk
@@ -3486,7 +3269,7 @@ UT: now => @com.spotify.song(), contains~(genres, "fun-punk") => @com.spotify.pl
 # snips-nlu/spotify-2148
 U: Play Tom Thacker through a top sort.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tom thacker")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("tom thacker"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2150
 U: I want to hear from Pepe Marchena song Delaware
@@ -3516,7 +3299,7 @@ UT: now => @com.spotify.song(), contains~(genres, "pop") => @com.spotify.play_so
 # snips-nlu/spotify-2162
 U: Play the greatest hits by Inoj .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("inoj")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("inoj"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2167
 U: I wish to listen to Gonna Get Along Without Ya Now by Ian Curtis .
@@ -3531,7 +3314,7 @@ UT: now => (@com.spotify.album(), id =~ "with echoes in the movement of stone" &
 # snips-nlu/spotify-2173
 U: Play Gary Jules's latest music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gary jules")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("gary jules"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2174
 U: Let's hear something from Elena Risteska
@@ -3576,7 +3359,7 @@ UT: now => (@com.spotify.artist(), id =~ "Bad Boy Bill")[1] => @com.spotify.play
 # snips-nlu/spotify-2195
 U: Play the latest Bobby Darin .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bobby darin")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("bobby darin"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2197
 U: Play the track Fight On, State by Yuvan Shankar Raja
@@ -3606,7 +3389,7 @@ UT: now => @com.spotify.song(), contains~(genres, "biguine") => @com.spotify.pla
 # snips-nlu/spotify-2212
 U: Play the latest Peter Green .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("peter green")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("peter green"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2214
 U: Play something from the genre muzyka pop
@@ -3661,7 +3444,7 @@ UT: now => (@com.spotify.album(), id =~ "addicts: black meddle, part ii")[1] => 
 # snips-nlu/spotify-2232
 U: Play the best music from Klaus Badelt .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("klaus badelt")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("klaus badelt"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2235
 U: Play a Nóta song
@@ -3676,12 +3459,12 @@ UT: now => (@com.spotify.song(), id =~ "on the good ship lollipop" && contains(a
 # snips-nlu/spotify-2245
 U: I want to hear the last album from Carsten Bohn
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("carsten bohn")) => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("carsten bohn"))))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-2251
 U: play the last Niney The Observer song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("niney the observer")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("niney the observer"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2253
 U: Play One Way Ticket by Ray Kennedy .
@@ -3691,7 +3474,7 @@ UT: now => (@com.spotify.song(), id =~ "one way ticket" && contains(artists, nul
 # snips-nlu/spotify-2258
 U: Please play the last track from abbath
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("abbath")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("abbath"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2261
 U: Play music by larry mullen jr.
@@ -3706,7 +3489,7 @@ UT: now => @com.spotify.song(), contains~(genres, "rumba africana") => @com.spot
 # snips-nlu/spotify-2268
 U: last song by Latifa
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("latifa")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("latifa"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2275
 U: I want to listen to the track Close To The Edge
@@ -3726,7 +3509,7 @@ UT: now => (@com.spotify.song(), id =~ "merrily we roll along" && contains(artis
 # snips-nlu/spotify-2278
 U: Play the newest Roger Troutman track possible
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("roger troutman")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("roger troutman"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2279
 U: Play some P. J. Proby
@@ -3776,7 +3559,7 @@ UT: now => (@com.spotify.album(), id =~ "the ladybug transistor" && contains(art
 # snips-nlu/spotify-2296
 U: Play the latest music from Mark Knopfler .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("mark knopfler")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("mark knopfler"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2298
 U: Play Tyrants And Wraiths
@@ -3787,4 +3570,3 @@ UT: now => (@com.spotify.album(), id =~ "tyrants and wraiths")[1] => @com.spotif
 U: Play Before I Grew Up To Love You by Wafah Dufour
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: now => (@com.spotify.song(), id =~ "before i grew up to love you" && contains(artists, null^^com.spotify:artist("wafah dufour")))[1] => @com.spotify.play_song(song=id);
-

--- a/main/com.spotify/eval/dev/annotated.txt
+++ b/main/com.spotify/eval/dev/annotated.txt
@@ -216,4132 +216,3575 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
 U: nope, bye .
 UT: $dialogue @org.thingpedia.dialogue.transaction.cancel;
 ====
-# nlu/spotify-3
+# snips-nlu/spotify-3
 U: play the Música Da Série De Filmes O Hobbit album by Alex Otaola
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "música da série de filmes o hobbit" && contains~(artists, "alex otaola") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "música da série de filmes o hobbit" && contains(artists, null^^com.spotify:artist("alex otaola")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-9
-U: Please play me Jerry Lee Lewis's If You Say So track.
+# snips-nlu/spotify-5
+U: Play The Soft Parade .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "jerry lee lewis") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "the soft parade")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-10
+# snips-nlu/spotify-9
+U: Please play me Jerry Lee Lewis's If You Say So track .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("jerry lee lewis")) && id =~ "if you say so")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-10
 U: play the newest by Exuma
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "exuma") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("exuma")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-11
-U: Play the album alas y raíces by Dave Pybus.
+# snips-nlu/spotify-11
+U: Play the album alas y raíces by Dave Pybus .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "alas y raíces" && contains~(artists, "dave pybus") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "alas y raíces" && contains(artists, null^^com.spotify:artist("dave pybus")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-12
+# snips-nlu/spotify-12
 U: play music by Helen Ward
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Helen Ward" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Helen Ward")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-14
-U: Plan an album by Roni Duani.
+# snips-nlu/spotify-14
+U: Plan an album by Roni Duani .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "roni duani") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("roni duani")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-16
-U: Play the best music by Arthur Johnston.
+# snips-nlu/spotify-16
+U: Play the best music by Arthur Johnston .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "arthur johnston") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("arthur johnston")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-17
+# snips-nlu/spotify-17
 U: Play the song gangsta? by Siavash Ghomayshi
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "siavash ghomayshi") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "gangsta" && contains(artists, null^^com.spotify:artist("siavash ghomayshi")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-24
+# snips-nlu/spotify-24
 U: Play Marche Lorraine by Rachael Lampa
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Rachael Lampa" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "marche lorraine" && contains(artists, null^^com.spotify:artist("rachael lampa")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-25
+# snips-nlu/spotify-25
 U: Play some soul music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "soul") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "soul") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-26
+# snips-nlu/spotify-26
 U: Play Robin Hood Rescuing Three Squires by Bhupinder Singh
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Bhupinder Singh" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "robin hood rescuing three squires" && contains(artists, null^^com.spotify:artist("bhupinder singh")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-35
+# snips-nlu/spotify-30
+U: play Shake Your Head
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "shake your head")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-35
 U: Play Inside The Eye by twinkie clark
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "inside the eye" && contains~(artists, "twinkie clark") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "inside the eye" && contains(artists, null^^com.spotify:artist("twinkie clark")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-39
+# snips-nlu/spotify-39
 U: Play Alone, Again from Mike Viola
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "alone, again" && contains~(artists, "mike viola") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "alone, again" && contains(artists, null^^com.spotify:artist("mike viola")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-43
+# snips-nlu/spotify-43
 U: Please play the newest music by Evil Jared Hasselhoff
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "evil jared hasselhoff") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("evil jared hasselhoff")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-46
+# snips-nlu/spotify-46
 U: Can you play a top 5 song by Manos Hadjidakis
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "manos hadjidakis") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("manos hadjidakis")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-48
+# snips-nlu/spotify-48
 U: Play music by Antonella Barba from the album Bath
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "antonella barba") && id =~ "bath" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("antonella barba")) && id =~ "bath")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-52
+# snips-nlu/spotify-52
 U: Play Out From Under from Hurricane Chris
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Hurricane Chris" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "out from under" && contains(artists, null^^com.spotify:artist("hurricane chris")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-54
-U: Play One Way Ticket by Ray Kennedy.
+# snips-nlu/spotify-54
+U: Play One Way Ticket by Ray Kennedy .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ray Kennedy" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "one way ticket" && contains(artists, null^^com.spotify:artist("ray kennedy")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-65
+# snips-nlu/spotify-65
 U: play music by Don Reno
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Don Reno" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Don Reno")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-79
+# snips-nlu/spotify-79
 U: Play celtic music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "celtic") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "celtic") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-80
+# snips-nlu/spotify-80
 U: play Moustapha Amar Make It Rain
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Moustapha Amar" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("moustapha amar")) && id =~ "make it rain")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-84
+# snips-nlu/spotify-84
 U: Play music from artist Ashley
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ashley" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Ashley")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-85
+# snips-nlu/spotify-85
 U: play Miguelito top charting album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains~(artists, "miguelito") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("miguelito")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-89
+# snips-nlu/spotify-89
 U: play songs by Wise
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Wise" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Wise")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-91
-U: I want to hear Ready by Frankenstein Drag Queens From Planet 13
+# snips-nlu/spotify-93
+U: Play something by Brian Chase .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "ready" && contains~(artists, "frankenstein drag queens from planet 13") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.artist(), id =~ "Brian Chase")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-93
-U: Play something by Brian Chase.
+# snips-nlu/spotify-97
+U: Play a tune from Space Mandino .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Brian Chase" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("space mandino")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-97
-U: Play a tune from Space Mandino.
-UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "space mandino") => notify;
-UT: now => @com.spotify.play_song(song=$?);
-====
-# nlu/spotify-99
+# snips-nlu/spotify-99
 U: Find me music by Kaori Utatsuki off the album that has top-twenty hits
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains~(artists, "kaori utatsuki") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("kaori utatsuki")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-101
-U: Play some thrash metal.
+# snips-nlu/spotify-101
+U: Play some thrash metal .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "thrash metal") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "thrash metal") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-105
+# snips-nlu/spotify-105
 U: Play the artist Joe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Joe" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Joe")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-106
+# snips-nlu/spotify-106
 U: play some Prabha Atre
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Prabha Atre" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Prabha Atre")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-113
+# snips-nlu/spotify-113
 U: Play Sense Tu from Ebi Hamedi
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ebi Hamedi" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "sense tu" && contains(artists, null^^com.spotify:artist("ebi hamedi")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-120
-U: Play some symphonic rock.
+# snips-nlu/spotify-120
+U: Play some symphonic rock .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "symphonic rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "symphonic rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-130
+# snips-nlu/spotify-130
 U: play music by Shinji Miyazaki
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Shinji Miyazaki" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Shinji Miyazaki")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-135
-U: Play Water Under The Bridge by Hariprasad Chaurasia.
+# snips-nlu/spotify-135
+U: Play Water Under The Bridge by Hariprasad Chaurasia .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Hariprasad Chaurasia" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "water under the bridge" && contains(artists, null^^com.spotify:artist("hariprasad chaurasia")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-137
-U: I want to hear Shooby Taylor's Tearing Up The Album Charts.
+# snips-nlu/spotify-137
+U: I want to hear Shooby Taylor's Tearing Up The Album Charts .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "shooby taylor") && id =~ "tearing up the album charts" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("shooby taylor")) && id =~ "tearing up the album charts")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-140
-U: Play Circus Farm by Deana Carter.
+# snips-nlu/spotify-140
+U: Play Circus Farm by Deana Carter .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Deana Carter" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "circus farm" && contains(artists, null^^com.spotify:artist("deana carter")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-142
+# snips-nlu/spotify-142
 U: play music by Bryan Maclean
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Bryan Maclean" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Bryan Maclean")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-147
+# snips-nlu/spotify-147
 U: Play tune from Sonny Stitt
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "sonny stitt") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sonny stitt")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-151
+# snips-nlu/spotify-150
+U: Play Tomorrow
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "tomorrow")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-151
 U: Can you play a sound track by Sissieretta Jones
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "sissieretta jones") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sissieretta jones")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-153
+# snips-nlu/spotify-153
 U: I want to hear Sarban's greatest hits
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "sarban") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sarban")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-159
+# snips-nlu/spotify-159
 U: Play Ciribiribin by Sandeep Khare
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Sandeep Khare" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "ciribiribin" && contains(artists, null^^com.spotify:artist("sandeep khare")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-163
-U: Play the top 5 by Akira The Don.
+# snips-nlu/spotify-163
+U: Play the top 5 by Akira The Don .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "akira the don") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("akira the don")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-167
+# snips-nlu/spotify-166
+U: play The Necromancer
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "the necromancer")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-167
 U: Can you play Under The Anheuser Bush by Pete Doherty
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Pete Doherty" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "under the anheuser bush" && contains(artists, null^^com.spotify:artist("pete doherty")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-170
+# snips-nlu/spotify-170
 U: Play Sound Of Love from Papa Mali
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Papa Mali" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "sound of love" && contains(artists, null^^com.spotify:artist("papa mali")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-173
+# snips-nlu/spotify-173
 U: Play Magic Time by Phoebus
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "magic time" && contains~(artists, "phoebus") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "magic time" && contains(artists, null^^com.spotify:artist("phoebus")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-174
+# snips-nlu/spotify-174
 U: Play Johnny Gimble
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Johnny Gimble" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Johnny Gimble")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-177
+# snips-nlu/spotify-177
 U: Play a tune by Andrew Findon
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "andrew findon") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("andrew findon")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-179
+# snips-nlu/spotify-179
 U: Play some chanson music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "chanson") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "chanson") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-182
+# snips-nlu/spotify-182
 U: Play music by Young Steff
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Young Steff" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Young Steff")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-187
+# snips-nlu/spotify-187
 U: Play music by Janet Paschal
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Janet Paschal" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Janet Paschal")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-191
+# snips-nlu/spotify-188
+U: Play Praise The Lord And Pass The Ammunition .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "praise the lord and pass the ammunition")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-191
 U: Play music by Damien Rice
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Damien Rice" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Damien Rice")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-194
-U: Play some Tony Grant.
+# snips-nlu/spotify-194
+U: Play some Tony Grant .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Tony Grant" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Tony Grant")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-195
+# snips-nlu/spotify-195
 U: play Andy White
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Andy White" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Andy White")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-200
+# snips-nlu/spotify-200
 U: play Robin Trower Unravel
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Robin Trower" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("robin trower")) && id =~ "unravel")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-203
+# snips-nlu/spotify-203
 U: Play the album Vibrations by Marion Elise Raven
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "vibrations" && contains~(artists, "marion elise raven") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "vibrations" && contains(artists, null^^com.spotify:artist("marion elise raven")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-205
+# snips-nlu/spotify-205
 U: play Jawad Ahmad
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Jawad Ahmad" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Jawad Ahmad")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-211
+# snips-nlu/spotify-211
 U: play Darude
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Darude" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Darude")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-213
+# snips-nlu/spotify-213
 U: Play 2gether by Jade Puget
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "2gether" && contains~(artists, "jade puget") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "2gether" && contains(artists, null^^com.spotify:artist("jade puget")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-214
+# snips-nlu/spotify-214
 U: play Wow by Jon Theodore
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Jon Theodore" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "wow" && contains(artists, null^^com.spotify:artist("jon theodore")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-215
+# snips-nlu/spotify-215
 U: play Doctor Fink if i could choose
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Doctor Fink" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("doctor fink")) && id =~ "if i could choose")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-217
+# snips-nlu/spotify-217
 U: Can I hear a tune from Vladimir Vysotski?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "vladimir vysotski") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("vladimir vysotski")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-218
-U: Please play Different Slanguages by Fred Labour.
+# snips-nlu/spotify-218
+U: Please play Different Slanguages by Fred Labour .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "different slanguages" && contains~(artists, "fred labour") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "different slanguages" && contains(artists, null^^com.spotify:artist("fred labour")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-225
+# snips-nlu/spotify-225
 U: play the album a kiss before you go by Bt
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "a kiss before you go" && contains~(artists, "bt") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "a kiss before you go" && contains(artists, null^^com.spotify:artist("bt")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-227
+# snips-nlu/spotify-227
 U: Play some salsa music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "salsa") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "salsa") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-228
+# snips-nlu/spotify-228
 U: Play top Rosanne Cash
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "rosanne cash") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("rosanne cash")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-233
+# snips-nlu/spotify-231
+U: Play Midnight Special
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "midnight special")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-233
 U: play Takes Place In Your Work Space by Eddie Kendricks
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "takes place in your work space" && contains~(artists, "eddie kendricks") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "takes place in your work space" && contains(artists, null^^com.spotify:artist("eddie kendricks")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-240
+# snips-nlu/spotify-240
 U: Play tribal
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "tribal") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "tribal") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-243
+# snips-nlu/spotify-243
 U: Repeat the track of music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "repeat")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-247
-U: Play Martha My Dear by shannon.
+# snips-nlu/spotify-247
+U: Play Martha My Dear by shannon .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "shannon" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "martha my dear" && contains(artists, null^^com.spotify:artist("shannon")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-248
+# snips-nlu/spotify-248
 U: play the greatest Adrian Kowanek music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "adrian kowanek") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("adrian kowanek")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-250
+# snips-nlu/spotify-250
 U: I'd like to listen to Space music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "space") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "space") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-251
+# snips-nlu/spotify-251
 U: play the last Niney The Observer song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "niney the observer") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("niney the observer")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-253
+# snips-nlu/spotify-253
 U: Play industrial music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "industrial") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "industrial") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-254
-U: Play always by walter parazaider.
+# snips-nlu/spotify-254
+U: Play always by walter parazaider .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "walter parazaider" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "always" && contains(artists, null^^com.spotify:artist("walter parazaider")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-264
+# snips-nlu/spotify-264
 U: Play music from the track She Came In Through The Bathroom Window
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "she came in through the bathroom window")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-265
+# snips-nlu/spotify-265
 U: play some best selling rave songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.artist(), contains~(genres, "rave") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains~(genres, "rave") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-267
+# snips-nlu/spotify-267
 U: Play the newest stuff by blowfly
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "blowfly") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("blowfly")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-273
+# snips-nlu/spotify-273
 U: play Clifford Brown All Stars by Michael Balzary
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "clifford brown all stars" && contains~(artists, "michael balzary") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "clifford brown all stars" && contains(artists, null^^com.spotify:artist("michael balzary")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-275
+# snips-nlu/spotify-275
 U: Play any chanson
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "chanson") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "chanson") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-277
+# snips-nlu/spotify-277
 U: Play Leanne Dobinson Right To Dream
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Leanne Dobinson" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("leanne dobinson")) && id =~ "right to dream")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-278
+# snips-nlu/spotify-278
 U: play The Happiest Days Of Our Lives by Tommy Emmanuel
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Tommy Emmanuel" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "the happiest days of our lives" && contains(artists, null^^com.spotify:artist("tommy emmanuel")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-279
-U: Please play This Is The Day by Brian Robertson.
+# snips-nlu/spotify-279
+U: Please play This Is The Day by Brian Robertson .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "this is the day" && contains~(artists, "brian robertson") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "this is the day" && contains(artists, null^^com.spotify:artist("brian robertson")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-281
-U: Play a new tune by louis silvers.
+# snips-nlu/spotify-281
+U: Play a new tune by louis silvers .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "louis silvers") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("louis silvers")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-282
+# snips-nlu/spotify-282
 U: Play me a song by Steve Hackett from Manuel
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "steve hackett") && id =~ "manuel" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("steve hackett")) && id =~ "manuel")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-285
+# snips-nlu/spotify-285
 U: play my tribute by Billy Cox
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Billy Cox" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "my tribute" && contains(artists, null^^com.spotify:artist("billy cox")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-295
+# snips-nlu/spotify-295
 U: Play the newest music by Gladys Knight
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "gladys knight") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gladys knight")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-296
+# snips-nlu/spotify-296
 U: play Hora Din Moldova by Yamazaki Maso
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Yamazaki Maso" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "hora din moldova" && contains(artists, null^^com.spotify:artist("yamazaki maso")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-299
+# snips-nlu/spotify-299
 U: Play me the track Mama Liked The Roses
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "mama liked the roses")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-302
+# snips-nlu/spotify-302
 U: Play some music from Roberto Carlos
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Roberto Carlos" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Roberto Carlos")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-306
+# snips-nlu/spotify-306
 U: Play A Chaos Of Desire from Dan Snaith
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "a chaos of desire" && contains~(artists, "dan snaith") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "a chaos of desire" && contains(artists, null^^com.spotify:artist("dan snaith")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-307
-U: Play music by Country Dick Montana.
+# snips-nlu/spotify-307
+U: Play music by Country Dick Montana .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Country Dick Montana" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Country Dick Montana")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-320
+# snips-nlu/spotify-320
 U: play music by Billy Powell
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Billy Powell" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Billy Powell")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-322
+# snips-nlu/spotify-322
 U: Play some fun-punk
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "fun-punk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "fun-punk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-325
+# snips-nlu/spotify-325
 U: I want to hear popular music from Martin Lopez
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "martin lopez") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("martin lopez")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-330
+# snips-nlu/spotify-330
 U: Play Lorenzo Palacios Quispe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Lorenzo Palacios Quispe" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Lorenzo Palacios Quispe")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-335
-U: Play some Glenn Miller.
+# snips-nlu/spotify-335
+U: Play some Glenn Miller .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Glenn Miller" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Glenn Miller")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-336
+# snips-nlu/spotify-336
 U: Can I hear a song by David Hodges?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "david hodges") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("david hodges")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-338
+# snips-nlu/spotify-338
 U: Play some P. J. Proby
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "P. J. Proby" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "P. J. Proby")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-346
+# snips-nlu/spotify-340
+U: Play The Lamentation Of Cloris
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "the lamentation of cloris")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-346
 U: Play me a song from Luxury Liner
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "luxury liner" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "luxury liner")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-352
-U: Please play good music by Will Oldham.
+# snips-nlu/spotify-352
+U: Please play good music by Will Oldham .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "will oldham") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("will oldham")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-354
+# snips-nlu/spotify-354
 U: play Vanlose Stairway by Janove Ottesen
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Janove Ottesen" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "vanlose stairway" && contains(artists, null^^com.spotify:artist("janove ottesen")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-356
+# snips-nlu/spotify-356
 U: Play music from the top-5 from artist Kenia Arias
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "kenia arias") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("kenia arias")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-358
+# snips-nlu/spotify-358
 U: Play some bass music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "bass") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "bass") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-373
+# snips-nlu/spotify-373
 U: Play me Gil Parris's A Cup Of Coffee, A Sandwich And You
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Gil Parris" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("gil parris")) && id =~ "a cup of coffee, a sandwich and you")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-381
+# snips-nlu/spotify-381
 U: play some synthpop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "synthpop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "synthpop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-386
-U: Play some Robbie Merrill.
+# snips-nlu/spotify-386
+U: Play some Robbie Merrill .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Robbie Merrill" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Robbie Merrill")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-390
+# snips-nlu/spotify-390
 U: Play new music from Liang Wern Fook
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "liang wern fook") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("liang wern fook")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-392
+# snips-nlu/spotify-392
 U: play By The Sleepy Lagoon by Greg Kurstin
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Greg Kurstin" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "by the sleepy lagoon" && contains(artists, null^^com.spotify:artist("greg kurstin")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-394
+# snips-nlu/spotify-394
 U: Play some gangsta music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "gangsta") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "gangsta") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-398
+# snips-nlu/spotify-398
 U: Play Eve
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Eve" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Eve")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-400
-U: Play some Psychedelic Rock.
+# snips-nlu/spotify-400
+U: Play some Psychedelic Rock .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "psychedelic rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "psychedelic rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-407
+# snips-nlu/spotify-407
 U: Play the red room sessions from chris cunningham
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the red room sessions" && contains~(artists, "chris cunningham") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the red room sessions" && contains(artists, null^^com.spotify:artist("chris cunningham")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-410
-U: Play music from Tommy Ridgley.
+# snips-nlu/spotify-410
+U: Play music from Tommy Ridgley .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Tommy Ridgley" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Tommy Ridgley")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-411
+# snips-nlu/spotify-411
 U: play All Of Your Toys by Chris Ledoux
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Chris Ledoux" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "all of your toys" && contains(artists, null^^com.spotify:artist("chris ledoux")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-412
-U: Play music by Fidel Nadal sorted by newest.
+# snips-nlu/spotify-412
+U: Play music by Fidel Nadal sorted by newest .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "fidel nadal") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fidel nadal")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-415
+# snips-nlu/spotify-415
 U: Play Dave Wyndorf album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "dave wyndorf") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("dave wyndorf")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-417
+# snips-nlu/spotify-417
 U: Play me something by Funtwo
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Funtwo" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Funtwo")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-418
+# snips-nlu/spotify-418
 U: Play some The Lady Is A Tramp from Timour Moutsouraev
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Timour Moutsouraev" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "the lady is a tramp" && contains(artists, null^^com.spotify:artist("timour moutsouraev")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-422
+# snips-nlu/spotify-422
 U: Can you play a song by Ken
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "ken") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("ken")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-425
-U: Play Bald by Kaskade.
+# snips-nlu/spotify-425
+U: Play Bald by Kaskade .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Kaskade" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "bald" && contains(artists, null^^com.spotify:artist("kaskade")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-430
+# snips-nlu/spotify-430
 U: Play some Gospel music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "gospel") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "gospel") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-431
+# snips-nlu/spotify-431
 U: Play satire
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "satire") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "satire") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-434
+# snips-nlu/spotify-434
 U: Play me some Terror music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "terror") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "terror") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-438
-U: Play some Rumba Africana.
+# snips-nlu/spotify-438
+U: Play some Rumba Africana .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "rumba africana") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "rumba africana") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-440
-U: Play a top-five song by Pete Candoli.
+# snips-nlu/spotify-440
+U: Play a top-five song by Pete Candoli .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "pete candoli") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("pete candoli")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-443
+# snips-nlu/spotify-443
 U: Can you play me some Pop-folk music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "pop-folk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "pop-folk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-453
+# snips-nlu/spotify-453
 U: play Bra Vibrationer by Dean
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Dean" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "bra vibrationer" && contains(artists, null^^com.spotify:artist("dean")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-456
-U: I want to hear the album Insult To Injury by Narayana Tirtha.
+# snips-nlu/spotify-456
+U: I want to hear the album Insult To Injury by Narayana Tirtha .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "insult to injury" && contains~(artists, "narayana tirtha") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "insult to injury" && contains(artists, null^^com.spotify:artist("narayana tirtha")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-457
+# snips-nlu/spotify-457
 U: play latest Shaggy music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "shaggy") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("shaggy")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-463
+# snips-nlu/spotify-463
 U: Play That Would Be Something by Eden Ahbez
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Eden Ahbez" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "that would be something" && contains(artists, null^^com.spotify:artist("eden ahbez")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-464
+# snips-nlu/spotify-464
 U: Please play Every Woman In Me
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "every woman in me" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "every woman in me")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-465
+# snips-nlu/spotify-465
 U: Play some Ven A Mi
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "ven a mi" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "ven a mi")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-468
+# snips-nlu/spotify-468
 U: play some gotye
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "gotye" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "gotye")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-469
+# snips-nlu/spotify-469
 U: play This Is Colour by Panda Bear
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Panda Bear" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "this is colour" && contains(artists, null^^com.spotify:artist("panda bear")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-470
+# snips-nlu/spotify-470
 U: Play songs by Cheryl Wheeler
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Cheryl Wheeler" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Cheryl Wheeler")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-472
+# snips-nlu/spotify-472
 U: Please play me something by New Wave Of American Heavy Metal
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "new wave of american heavy metal") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "new wave of american heavy metal") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-474
+# snips-nlu/spotify-474
 U: Play me the best Charles Neidich song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "charles neidich") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("charles neidich")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-481
+# snips-nlu/spotify-481
 U: Play the Ricky Wilson album Spectral Dusk
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "ricky wilson") && id =~ "spectral dusk" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("ricky wilson")) && id =~ "spectral dusk")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-482
-U: Play Red Barchetta by Blind Lemon Jefferson.
+# snips-nlu/spotify-482
+U: Play Red Barchetta by Blind Lemon Jefferson .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Blind Lemon Jefferson" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "red barchetta" && contains(artists, null^^com.spotify:artist("blind lemon jefferson")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-483
+# snips-nlu/spotify-483
 U: Play the track R U Professional by Roberto Carlos Braga
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "roberto carlos braga") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "r u professional" && contains(artists, null^^com.spotify:artist("roberto carlos braga")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-488
+# snips-nlu/spotify-488
 U: Play The Fool On The Hill by Khwaja Ghulam Farid
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Khwaja Ghulam Farid" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "the fool on the hill" && contains(artists, null^^com.spotify:artist("khwaja ghulam farid")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-490
+# snips-nlu/spotify-490
 U: Play something by Chris Knight
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Chris Knight" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Chris Knight")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-494
+# snips-nlu/spotify-494
 U: Play Chantal Kreviazuk, Sister Ray
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Chantal Kreviazuk" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("chantal kreviazuk")) && id =~ "sister ray")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-496
+# snips-nlu/spotify-496
 U: play Only Hope by Graham Bonnet
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Graham Bonnet" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "only hope" && contains(artists, null^^com.spotify:artist("graham bonnet")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-498
+# snips-nlu/spotify-498
 U: Play gothic music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "gothic") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "gothic") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-505
+# snips-nlu/spotify-499
+U: I want to hear Song For Adam
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "song for adam")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-505
 U: play songs by Sarah Harding
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Sarah Harding" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Sarah Harding")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-506
+# snips-nlu/spotify-506
 U: Play Maggot Brain by Albano Carrisi
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Albano Carrisi" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "maggot brain" && contains(artists, null^^com.spotify:artist("albano carrisi")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-508
+# snips-nlu/spotify-508
 U: I want to hear the top Tim Madison
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "tim madison") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tim madison")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-510
+# snips-nlu/spotify-510
 U: Play the best songs by Jes Brieden
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "jes brieden") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jes brieden")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-511
+# snips-nlu/spotify-511
 U: Play me a song by Kevin Cadogan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "kevin cadogan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("kevin cadogan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-515
+# snips-nlu/spotify-515
 U: Please play a song by Everlast
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "everlast") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("everlast")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-517
+# snips-nlu/spotify-517
 U: Play music by Paul Mccartney
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Paul Mccartney" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Paul Mccartney")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-519
+# snips-nlu/spotify-519
 U: Play easy listening
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "easy listening") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "easy listening") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-523
+# snips-nlu/spotify-523
 U: play Lily, Rosemary And The Jack Of Hearts by Chris Goss
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Chris Goss" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "lily, rosemary and the jack of hearts" && contains(artists, null^^com.spotify:artist("chris goss")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-525
-U: Play Brenda Kahn's Rushall Station.
+# snips-nlu/spotify-525
+U: Play Brenda Kahn's Rushall Station .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "brenda kahn") && id =~ "rushall station" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("brenda kahn")) && id =~ "rushall station")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-526
+# snips-nlu/spotify-526
 U: play the top five songs by Isaac Hayes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "isaac hayes") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("isaac hayes")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-530
+# snips-nlu/spotify-530
 U: Play top 20 from frank farian
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "frank farian") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("frank farian")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-532
+# snips-nlu/spotify-532
 U: Play some psychadelic music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "psychadelic") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "psychadelic") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-533
-U: Play some Geir Jenssen.
+# snips-nlu/spotify-533
+U: Play some Geir Jenssen .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Geir Jenssen" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Geir Jenssen")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-540
+# snips-nlu/spotify-540
 U: Please play Kabhi Jo Baadal Barse by Ruth Lorenzo
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ruth Lorenzo" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "kabhi jo baadal barse" && contains(artists, null^^com.spotify:artist("ruth lorenzo")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-544
+# snips-nlu/spotify-544
 U: play a sound track by Tom Thacker
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "tom thacker") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("tom thacker")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-545
-U: Play some Laurie Anderson.
+# snips-nlu/spotify-545
+U: Play some Laurie Anderson .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Laurie Anderson" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Laurie Anderson")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-549
+# snips-nlu/spotify-549
 U: Play the track Grow Old With Me by artist Chloe Rose Lattanzi
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "chloe rose lattanzi") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "grow old with me" && contains(artists, null^^com.spotify:artist("chloe rose lattanzi")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-551
+# snips-nlu/spotify-551
 U: play Kings Of The Wild Frontier by Andrea Bocelli
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "kings of the wild frontier" && contains~(artists, "andrea bocelli") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "kings of the wild frontier" && contains(artists, null^^com.spotify:artist("andrea bocelli")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-555
+# snips-nlu/spotify-555
 U: Play Bob Hilliard top-twenty music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "bob hilliard") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bob hilliard")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-559
+# snips-nlu/spotify-559
 U: I want to hear Techno-industrial music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "techno-industrial") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "techno-industrial") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-561
+# snips-nlu/spotify-561
 U: Play Julie Driscoll
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Julie Driscoll" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Julie Driscoll")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-564
+# snips-nlu/spotify-564
 U: play songs by Sammy Fain
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Sammy Fain" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Sammy Fain")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-573
+# snips-nlu/spotify-569
+U: play some Alte Kameraden music
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "alte kameraden")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-573
 U: Play genre opera
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "opera") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "opera") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-578
+# snips-nlu/spotify-578
 U: I want to hear Box Of Rain by Skeets Mcdonald
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Skeets Mcdonald" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "box of rain" && contains(artists, null^^com.spotify:artist("skeets mcdonald")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-583
+# snips-nlu/spotify-579
+U: Please play Casino Boogie
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "casino boogie")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-583
 U: Play something by Louisiana Blues
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "louisiana blues") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "louisiana blues") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-584
+# snips-nlu/spotify-584
 U: Play new Ian Mclagan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "ian mclagan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ian mclagan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-588
+# snips-nlu/spotify-588
 U: Play Before I Grew Up To Love You by Wafah Dufour
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Wafah Dufour" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "before i grew up to love you" && contains(artists, null^^com.spotify:artist("wafah dufour")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-595
+# snips-nlu/spotify-593
+U: Play Fight On, State .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "fight on, state")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-595
 U: Play the top five Cemil Bey songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "cemil bey") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("cemil bey")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-597
+# snips-nlu/spotify-597
 U: play music by Francis Healy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Francis Healy" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Francis Healy")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-603
+# snips-nlu/spotify-603
 U: Play Rei Momo newest album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), id =~ "rei momo" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (sort release_date desc of @com.spotify.album(), id =~ "rei momo")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-608
+# snips-nlu/spotify-608
 U: Play Punk Rock music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "punk rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "punk rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-609
-U: Play something by Louis Nelson Delisle.
+# snips-nlu/spotify-609
+U: Play something by Louis Nelson Delisle .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Louis Nelson Delisle" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Louis Nelson Delisle")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-613
+# snips-nlu/spotify-613
 U: Play Revival music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "revival") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "revival") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-615
+# snips-nlu/spotify-615
 U: play the song Si No Te Hubiera Conocido by Haidar Salim
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "haidar salim") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "si no te hubiera conocido" && contains(artists, null^^com.spotify:artist("haidar salim")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-617
+# snips-nlu/spotify-617
 U: Open the playlist from Sergei Chatschatrjan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Sergei Chatschatrjan" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Sergei Chatschatrjan")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-619
+# snips-nlu/spotify-619
 U: play the Gary Chaw album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "gary chaw") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("gary chaw")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-620
+# snips-nlu/spotify-620
 U: Play me some grunge music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "grunge") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "grunge") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-622
+# snips-nlu/spotify-622
 U: Play The Garden Of Allah  from Wade Mainer
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Wade Mainer" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "the garden of allah" && contains(artists, null^^com.spotify:artist("wade mainer")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-623
-U: Play Alles Heeft Ritme by Liu Tianhua.
+# snips-nlu/spotify-623
+U: Play Alles Heeft Ritme by Liu Tianhua .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Liu Tianhua" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "alles heeft ritme" && contains(artists, null^^com.spotify:artist("liu tianhua")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-624
+# snips-nlu/spotify-624
 U: Play the best Vanessa Peters songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "vanessa peters") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("vanessa peters")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-625
+# snips-nlu/spotify-625
 U: Play That Stubborn Kinda Fellow by Michael Amott
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "that stubborn kinda fellow" && contains~(artists, "michael amott") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "that stubborn kinda fellow" && contains(artists, null^^com.spotify:artist("michael amott")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-628
+# snips-nlu/spotify-628
 U: Play Andy Williams Sings Rodgers And Hammerstein by elica todorova
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "andy williams sings rodgers and hammerstein" && contains~(artists, "elica todorova") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "andy williams sings rodgers and hammerstein" && contains(artists, null^^com.spotify:artist("elica todorova")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-629
-U: Play Tujiko Noriko's Ten Years And Running.
+# snips-nlu/spotify-629
+U: Play Tujiko Noriko's Ten Years And Running .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "tujiko noriko") && id =~ "ten years and running" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("tujiko noriko")) && id =~ "ten years and running")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-631
+# snips-nlu/spotify-631
 U: Play christian gangsta rap
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "christian gangsta rap") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "christian gangsta rap") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-641
+# snips-nlu/spotify-641
 U: play the most popular Miles Jones track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "miles jones") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("miles jones")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-644
+# snips-nlu/spotify-644
 U: Play slow rock music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "slow rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "slow rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-647
+# snips-nlu/spotify-647
 U: Play the song I Get Ideas as performed by Richard Kruspe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "richard kruspe") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "i get ideas" && contains(artists, null^^com.spotify:artist("richard kruspe")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-653
+# snips-nlu/spotify-653
 U: Play the tune by Adam Yauch
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "adam yauch") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("adam yauch")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-657
+# snips-nlu/spotify-657
 U: Play a popular Gurdas Maan track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "gurdas maan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gurdas maan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-660
+# snips-nlu/spotify-660
 U: Play the top-20 music by merz
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "merz") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("merz")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-662
+# snips-nlu/spotify-662
 U: Play a Mike Osborne song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "mike osborne") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mike osborne")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-665
+# snips-nlu/spotify-665
 U: Play Elysium from Ryan Cayabyab
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "elysium" && contains~(artists, "ryan cayabyab") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "elysium" && contains(artists, null^^com.spotify:artist("ryan cayabyab")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-666
+# snips-nlu/spotify-666
 U: play Matt Walker tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Matt Walker" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Matt Walker")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-677
+# snips-nlu/spotify-677
 U: play an Masaki Aiba tune
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "masaki aiba") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("masaki aiba")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-678
+# snips-nlu/spotify-678
 U: play Morning Song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "morning song" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "morning song")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-681
+# snips-nlu/spotify-681
 U: play Hardcore music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "hardcore") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "hardcore") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-690
+# snips-nlu/spotify-683
+U: play Wait Until Tomorrow
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "wait until tomorrow")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-687
+U: Play me a bluegrass song
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => @com.spotify.song(), contains~(genres, "bluegrass") => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-690
 U: Play pop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "pop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "pop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-694
+# snips-nlu/spotify-694
 U: Play Michael Angelo Batio
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Michael Angelo Batio" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Michael Angelo Batio")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-701
+# snips-nlu/spotify-701
 U: Play In Every Dream Home A Heartache by vincent paul abbott 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "vincent paul abbott" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "in every dream home a heartache" && contains(artists, null^^com.spotify:artist("vincent paul abbott")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-704
-U: Play the best song by Henry Rollins.
+# snips-nlu/spotify-704
+U: Play the best song by Henry Rollins .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "henry rollins") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("henry rollins")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-715
+# snips-nlu/spotify-715
 U: play the last track by Shavo Odadjian
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "shavo odadjian") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("shavo odadjian")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-716
+# snips-nlu/spotify-716
 U: Play Brotherhood by Ock Joo-hyun
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "brotherhood" && contains~(artists, "ock joo-hyun") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "brotherhood" && contains(artists, null^^com.spotify:artist("ock joo-hyun")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-717
+# snips-nlu/spotify-717
 U: play latest George Ducas music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "george ducas") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("george ducas")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-720
+# snips-nlu/spotify-719
+U: play I Could Write A Book
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "i could write a book")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-720
 U: listen to acapella
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "acapella") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "acapella") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-726
+# snips-nlu/spotify-726
 U: I want to listen to Speed Metal Symphony
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "speed metal symphony" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "speed metal symphony")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-746
-U: Play some Dave Pearce.
+# snips-nlu/spotify-734
+U: Please play Got The Time
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Dave Pearce" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "got the time")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-747
+# snips-nlu/spotify-746
+U: Play some Dave Pearce .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.artist(), id =~ "Dave Pearce")[1] => @com.spotify.play_artist(artist=id);
+====
+# snips-nlu/spotify-747
 U: play track Her Majesty
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "her majesty")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-748
+# snips-nlu/spotify-748
 U: I want to hear the newest music from The Railway Children
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "the railway children") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("the railway children")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-750
+# snips-nlu/spotify-750
 U: I want to hear Vegetables by pharrell williams
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "pharrell williams" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "vegetables" && contains(artists, null^^com.spotify:artist("pharrell williams")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-751
+# snips-nlu/spotify-751
 U: Play the album Making Evening And Night by Cevin Key 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "making evening and night" && contains~(artists, "cevin key") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "making evening and night" && contains(artists, null^^com.spotify:artist("cevin key")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-755
+# snips-nlu/spotify-755
 U: Play the Mother Lode by Tamio Okuda
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "mother lode" && contains~(artists, "tamio okuda") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "mother lode" && contains(artists, null^^com.spotify:artist("tamio okuda")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-759
+# snips-nlu/spotify-759
 U: Play me a song by Stephen Jones
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "stephen jones") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("stephen jones")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-762
+# snips-nlu/spotify-762
 U: Play some Game music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "game") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "game") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-766
+# snips-nlu/spotify-766
 U: play some grunge
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "grunge") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "grunge") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-767
-U: Play some Sam Moore.
+# snips-nlu/spotify-767
+U: Play some Sam Moore .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Sam Moore" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Sam Moore")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-771
+# snips-nlu/spotify-768
+U: play Mikazuki Sunset
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "mikazuki sunset")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-771
 U: play Peja tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Peja" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Peja")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-774
+# snips-nlu/spotify-774
 U: Play the track titled Faget
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "faget")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-775
+# snips-nlu/spotify-775
 U: Play the top song by Jack Grisham
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "jack grisham") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jack grisham")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-776
+# snips-nlu/spotify-776
 U: Please play Jag Vill Leva I Europa by porta
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "porta" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "jag vill leva i europa" && contains(artists, null^^com.spotify:artist("porta")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-781
+# snips-nlu/spotify-781
 U: play a song by Fats Waller
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "fats waller") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("fats waller")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-784
+# snips-nlu/spotify-784
 U: Play some music by Daniel Carter
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Daniel Carter" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Daniel Carter")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-787
+# snips-nlu/spotify-787
 U: Can you play a sonata
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "sonata") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "sonata") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-792
+# snips-nlu/spotify-792
 U: Play some dance music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "dance") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "dance") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-798
+# snips-nlu/spotify-798
 U: Play music by Ian Haugland
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ian Haugland" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Ian Haugland")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-799
+# snips-nlu/spotify-799
 U: Play some Drum & Bass
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "drum & bass") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "drum & bass") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-803
+# snips-nlu/spotify-803
 U: Can you play Crossover?
 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "crossover") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "crossover") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-806
+# snips-nlu/spotify-806
 U: play the album Everybody Happy by Lee Aaron
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "everybody happy" && contains~(artists, "lee aaron") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "everybody happy" && contains(artists, null^^com.spotify:artist("lee aaron")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-809
+# snips-nlu/spotify-809
 U: play the album How Insensitive
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "how insensitive" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "how insensitive")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-811
-U: Play Used To Love Her by Dara.
+# snips-nlu/spotify-811
+U: Play Used To Love Her by Dara .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Dara" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "used to love her" && contains(artists, null^^com.spotify:artist("dara")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-813
+# snips-nlu/spotify-813
 U: play music by Cass Elliot
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Cass Elliot" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Cass Elliot")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-816
+# snips-nlu/spotify-815
+U: Play On My Own
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "on my own")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-816
 U: Play Nick Hexum latest album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains~(artists, "nick hexum") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("nick hexum")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-819
+# snips-nlu/spotify-819
 U: Play the sound track by Ferry Corsten
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "ferry corsten") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("ferry corsten")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-824
+# snips-nlu/spotify-824
 U: play Say A Word by La India
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "La India" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "say a word" && contains(artists, null^^com.spotify:artist("la india")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-826
+# snips-nlu/spotify-826
 U: Play music from Paul Landers
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Paul Landers" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Paul Landers")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-827
-U: Play Taiwan Is Good by Kotoko.
+# snips-nlu/spotify-827
+U: Play Taiwan Is Good by Kotoko .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Kotoko" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "taiwan is good" && contains(artists, null^^com.spotify:artist("kotoko")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-828
+# snips-nlu/spotify-828
 U: I'm in the mood to listen to meditative music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "meditative") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "meditative") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-829
+# snips-nlu/spotify-829
 U: Play Hughie Graham by Vidyadhar Vyas
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Vidyadhar Vyas" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "hughie graham" && contains(artists, null^^com.spotify:artist("vidyadhar vyas")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-834
+# snips-nlu/spotify-834
 U: play the track The Wizard And I
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "the wizard and i")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-841
+# snips-nlu/spotify-841
 U: play Addicted To You by Hank Ballard
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Hank Ballard" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "addicted to you" && contains(artists, null^^com.spotify:artist("hank ballard")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-843
+# snips-nlu/spotify-843
 U: Play music by Keren Woodward
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Keren Woodward" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Keren Woodward")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-846
+# snips-nlu/spotify-846
 U: Play the song Little Robin Redbreast
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "little robin redbreast")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-847
+# snips-nlu/spotify-847
 U: Play music from the artist Irma Pane
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Irma Pane" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Irma Pane")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-849
+# snips-nlu/spotify-849
 U: Play the music of Tupac Shakur
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Tupac Shakur" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Tupac Shakur")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-852
+# snips-nlu/spotify-852
 U: Play the music genre Synthpop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "synthpop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "synthpop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-857
+# snips-nlu/spotify-857
 U: Play some showtunes music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "showtunes") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "showtunes") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-862
+# snips-nlu/spotify-859
+U: play There Must Be More To Life Than This
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "there must be more to life than this")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-862
 U: Play the new music from Wilko Johnson
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "wilko johnson") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("wilko johnson")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-865
+# snips-nlu/spotify-865
 U: Play the album Shooting Silvio by Dave Sabo
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "shooting silvio" && contains~(artists, "dave sabo") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "shooting silvio" && contains(artists, null^^com.spotify:artist("dave sabo")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-875
-U: Play Seaside by Don Cherry.
+# snips-nlu/spotify-875
+U: Play Seaside by Don Cherry .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "seaside" && contains~(artists, "don cherry") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "seaside" && contains(artists, null^^com.spotify:artist("don cherry")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-878
+# snips-nlu/spotify-878
 U: play top tunes by Joseph Utsler
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "joseph utsler") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("joseph utsler")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-879
+# snips-nlu/spotify-879
 U: play southern rock tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "southern rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "southern rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-883
+# snips-nlu/spotify-883
 U: Please play songs by Lil Jon
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Lil Jon" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Lil Jon")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-884
+# snips-nlu/spotify-884
 U: play Victoria Banks's album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "victoria banks") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("victoria banks")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-885
+# snips-nlu/spotify-885
 U: play a song by Busta Rhymes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "busta rhymes") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("busta rhymes")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-890
+# snips-nlu/spotify-890
 U: I want to hear the top 5 Jamie Lidell songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "jamie lidell") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jamie lidell")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-893
+# snips-nlu/spotify-893
 U: play Wolves by Larry Gatlin
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Larry Gatlin" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "wolves" && contains(artists, null^^com.spotify:artist("larry gatlin")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-894
+# snips-nlu/spotify-894
 U: Play That Stubborn Kinda Fellow by Michael Amott
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "that stubborn kinda fellow" && contains~(artists, "michael amott") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "that stubborn kinda fellow" && contains(artists, null^^com.spotify:artist("michael amott")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-895
+# snips-nlu/spotify-895
 U: play Long Way To Go by Keita Tachibana
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Keita Tachibana" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "long way to go" && contains(artists, null^^com.spotify:artist("keita tachibana")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-897
+# snips-nlu/spotify-897
 U: Play album from Maureen Mcgovern
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "maureen mcgovern") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("maureen mcgovern")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-900
-U: Play the newest Phil Stacey.
+# snips-nlu/spotify-900
+U: Play the newest Phil Stacey .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "phil stacey") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("phil stacey")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-909
+# snips-nlu/spotify-909
 U: Play a song off the Nicht Sprechen album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "nicht sprechen" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "nicht sprechen")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-911
+# snips-nlu/spotify-911
 U: play Isaac Yamma Slut
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "isaac yamma") && id =~ "slut" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("isaac yamma")) && id =~ "slut")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-918
+# snips-nlu/spotify-918
 U: Play the last Wellman Braud album relaesd 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "wellman braud") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("wellman braud")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-923
-U: Play the latest Joan Baez.
+# snips-nlu/spotify-923
+U: Play the latest Joan Baez .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "joan baez") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("joan baez")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-924
+# snips-nlu/spotify-924
 U: Play the album Qr Iii by bobby bare
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "qr iii" && contains~(artists, "bobby bare") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "qr iii" && contains(artists, null^^com.spotify:artist("bobby bare")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-925
-U: Play Les Pauvres Riches by Pan Mei Chen.
+# snips-nlu/spotify-925
+U: Play Les Pauvres Riches by Pan Mei Chen .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "les pauvres riches" && contains~(artists, "pan mei chen") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "les pauvres riches" && contains(artists, null^^com.spotify:artist("pan mei chen")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-928
-U: I'd like to hear Cry Baby Cry by Ally Kerr.
+# snips-nlu/spotify-928
+U: I'd like to hear Cry Baby Cry by Ally Kerr .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ally Kerr" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "cry baby cry" && contains(artists, null^^com.spotify:artist("ally kerr")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-929
+# snips-nlu/spotify-929
 U: play a top-twenty tune by Noor Jehan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "noor jehan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("noor jehan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-931
+# snips-nlu/spotify-931
 U: Do you have something like Impossible Is Nothing by Abderrahmane Abdelli?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Abderrahmane Abdelli" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "impossible is nothing" && contains(artists, null^^com.spotify:artist("abderrahmane abdelli")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-934
-U: Play some gothic rock.
+# snips-nlu/spotify-934
+U: Play some gothic rock .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "gothic rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "gothic rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-946
+# snips-nlu/spotify-946
 U: Can you play a song off the album, jungle
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "jungle" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "jungle")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-948
+# snips-nlu/spotify-948
 U: play songs by Gamble Rogers
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Gamble Rogers" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Gamble Rogers")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-950
+# snips-nlu/spotify-950
 U: Play a tune by Layne Staley
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "layne staley") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("layne staley")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-952
+# snips-nlu/spotify-952
 U: Play Tanti Auguri A Te from Bruce Gilbert
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Bruce Gilbert" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "tanti auguri a te" && contains(artists, null^^com.spotify:artist("bruce gilbert")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-956
+# snips-nlu/spotify-956
 U: play the greatest james yorkston song
 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "james yorkston") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("james yorkston")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-957
+# snips-nlu/spotify-957
 U: I want to hear the Live At Slane Castle album by Haifa Wehbe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "live at slane castle" && contains~(artists, "haifa wehbe") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "live at slane castle" && contains(artists, null^^com.spotify:artist("haifa wehbe")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-960
+# snips-nlu/spotify-960
 U: play Dick Marx
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Dick Marx" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Dick Marx")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-963
+# snips-nlu/spotify-963
 U: Play Anweshaa by the new first.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "anweshaa") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("anweshaa")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-971
+# snips-nlu/spotify-971
 U: Play sugar baby by frank beard
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "frank beard" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "sugar baby" && contains(artists, null^^com.spotify:artist("frank beard")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-973
+# snips-nlu/spotify-973
 U: Play Divine from Vinnie Roslin
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Vinnie Roslin" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "divine" && contains(artists, null^^com.spotify:artist("vinnie roslin")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-980
+# snips-nlu/spotify-976
+U: play No More Sorrow
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "no more sorrow")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-980
 U: Play track Cabbage by Keiji Haino
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "keiji haino") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "cabbage" && contains(artists, null^^com.spotify:artist("keiji haino")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-981
+# snips-nlu/spotify-981
 U: Play some music by beverley martyn
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "beverley martyn" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "beverley martyn")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-985
+# snips-nlu/spotify-985
 U: Play me some folklore music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "folklore") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "folklore") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-990
+# snips-nlu/spotify-990
 U: Play the Busco Un Pueblo album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "busco un pueblo" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "busco un pueblo")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-996
-U: Play some art punk.
+# snips-nlu/spotify-996
+U: Play some art punk .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "art punk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "art punk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1000
+# snips-nlu/spotify-1000
 U: Play me the most popular Arthur Johnston song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "arthur johnston") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("arthur johnston")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1002
+# snips-nlu/spotify-1002
 U: play Tonight Only! by Nastya Kamenskih
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "tonight only!" && contains~(artists, "nastya kamenskih") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "tonight only!" && contains(artists, null^^com.spotify:artist("nastya kamenskih")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1003
+# snips-nlu/spotify-1003
 U: Play songs by Naomi Schemer
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Naomi Schemer" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Naomi Schemer")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1007
-U: Play music by Don Cherry.
+# snips-nlu/spotify-1007
+U: Play music by Don Cherry .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Don Cherry" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Don Cherry")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1009
+# snips-nlu/spotify-1009
 U: Play the album Killer Instinkt
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "killer instinkt" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "killer instinkt")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1013
+# snips-nlu/spotify-1013
 U: Play some Maynard James Keenan songs from Scenes From The Big Chair
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "maynard james keenan") && id =~ "scenes from the big chair" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("maynard james keenan")) && id =~ "scenes from the big chair")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1024
+# snips-nlu/spotify-1024
 U: Play me the greatest Howard Levy song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "howard levy") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("howard levy")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1037
+# snips-nlu/spotify-1037
 U: Play some new age music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "new age") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "new age") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1038
+# snips-nlu/spotify-1038
 U: I want to hear any top five music from Gene Autry
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "gene autry") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gene autry")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1039
+# snips-nlu/spotify-1039
 U: play music by Vybz Kartel
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Vybz Kartel" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Vybz Kartel")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1040
+# snips-nlu/spotify-1040
 U: Can I hear the latest music from Bahar Kizil?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "bahar kizil") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bahar kizil")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1042
+# snips-nlu/spotify-1042
 U: Play Humour
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "humour") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "humour") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1052
-U: Play the top-twenty from Alexander Braginsky.
+# snips-nlu/spotify-1052
+U: Play the top-twenty from Alexander Braginsky .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "alexander braginsky") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("alexander braginsky")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1055
-U: Play the top 10 by Sankha Chatterjee.
+# snips-nlu/spotify-1055
+U: Play the top 10 by Sankha Chatterjee .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "sankha chatterjee") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sankha chatterjee")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1056
+# snips-nlu/spotify-1056
 U: Play music by Nick La Rocca
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Nick La Rocca" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Nick La Rocca")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1058
+# snips-nlu/spotify-1058
 U: Play the track That Would Be Something from Eden Ahbez
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "eden ahbez") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "that would be something" && contains(artists, null^^com.spotify:artist("eden ahbez")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1069
+# snips-nlu/spotify-1069
 U: play some Folk tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "folk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "folk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1071
+# snips-nlu/spotify-1071
 U: Play some music by Mutlu
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Mutlu" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Mutlu")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1074
-U: Play some happy gabber.
+# snips-nlu/spotify-1074
+U: Play some happy gabber .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "happy gabber") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "happy gabber") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1075
+# snips-nlu/spotify-1075
 U: I want to hear some psychedelic rock
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "psychedelic rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "psychedelic rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1082
+# snips-nlu/spotify-1082
 U: Play prints in the stone by Helen Baylor
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "prints in the stone" && contains~(artists, "helen baylor") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "prints in the stone" && contains(artists, null^^com.spotify:artist("helen baylor")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1085
+# snips-nlu/spotify-1085
 U: I want to hear some acid punk music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "acid punk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "acid punk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1086
+# snips-nlu/spotify-1086
 U: Play some music from Miss Platnum
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Miss Platnum" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Miss Platnum")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1087
+# snips-nlu/spotify-1087
 U: play Christina Milian latest music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "christina milian") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("christina milian")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1094
-U: Play Richard Fortus' Live Collection.
+# snips-nlu/spotify-1094
+U: Play Richard Fortus' Live Collection .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "richard fortus") && id =~ "live collection" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("richard fortus")) && id =~ "live collection")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1101
+# snips-nlu/spotify-1101
 U: play Wanted by Erykah Badu
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Erykah Badu" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "wanted" && contains(artists, null^^com.spotify:artist("erykah badu")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1102
+# snips-nlu/spotify-1102
 U: Play some Christian Rock
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "christian rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "christian rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1103
+# snips-nlu/spotify-1103
 U: Play some Retro music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "retro") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "retro") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1105
+# snips-nlu/spotify-1105
 U: Play Mea Culpa by Rahim Shah
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "mea culpa" && contains~(artists, "rahim shah") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "mea culpa" && contains(artists, null^^com.spotify:artist("rahim shah")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1106
+# snips-nlu/spotify-1106
 U: Play Acid Punk music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "acid punk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "acid punk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1109
-U: Play The Birds And The Bees by Ceca.
+# snips-nlu/spotify-1109
+U: Play The Birds And The Bees by Ceca .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ceca" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "the birds and the bees" && contains(artists, null^^com.spotify:artist("ceca")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1113
-U: Play Rap Album One by Gene Vincent.
+# snips-nlu/spotify-1113
+U: Play Rap Album One by Gene Vincent .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "rap album one" && contains~(artists, "gene vincent") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "rap album one" && contains(artists, null^^com.spotify:artist("gene vincent")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1115
+# snips-nlu/spotify-1115
 U: I'd like to hear Don Airey's Gonna Raise Hell
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Don Airey" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("don airey")) && id =~ "gonna raise hell")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1116
+# snips-nlu/spotify-1116
 U: Can you play some music by andrew diamond
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "andrew diamond" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "andrew diamond")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1121
+# snips-nlu/spotify-1121
 U: play some Kansas Joe Mccoy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Kansas Joe Mccoy" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Kansas Joe Mccoy")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1123
+# snips-nlu/spotify-1123
 U: Play some folk-rock music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "folk-rock") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "folk-rock") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1132
+# snips-nlu/spotify-1132
 U: play Sivamani
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Sivamani" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Sivamani")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1133
+# snips-nlu/spotify-1133
 U: Can you play the greatest sarah brightman song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "sarah brightman") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sarah brightman")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1136
+# snips-nlu/spotify-1136
 U: play the song Shine A Light
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "shine a light")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1146
+# snips-nlu/spotify-1146
 U: play Frankie Laine
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Frankie Laine" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Frankie Laine")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1148
+# snips-nlu/spotify-1148
 U: play the top five songs by Gad Elbaz
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "gad elbaz") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gad elbaz")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1153
+# snips-nlu/spotify-1153
 U: play Fill Yourself With Music by Ray Manzarek
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "fill yourself with music" && contains~(artists, "ray manzarek") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "fill yourself with music" && contains(artists, null^^com.spotify:artist("ray manzarek")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1155
+# snips-nlu/spotify-1154
+U: Play Contigo En La Distancia
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "contigo en la distancia")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-1155
 U: play some dream music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "dream") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "dream") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1161
+# snips-nlu/spotify-1161
 U: Play some chanson music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "chanson") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "chanson") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1163
+# snips-nlu/spotify-1163
 U: Play the latest music by Martin Luther Mccoy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "martin luther mccoy") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("martin luther mccoy")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1169
+# snips-nlu/spotify-1169
 U: play the top twenty tracks of Ron Jarzombek
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "ron jarzombek") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ron jarzombek")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1171
+# snips-nlu/spotify-1171
 U: Play me a tune by john clayton
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "john clayton") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("john clayton")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1174
+# snips-nlu/spotify-1174
 U: can you play some weird music from the noise genre
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "noise") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "noise") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1176
+# snips-nlu/spotify-1176
 U: Play Larry Graham sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "larry graham") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("larry graham")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1178
+# snips-nlu/spotify-1178
 U: play Roland Alphonso tunes that are most popular
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "roland alphonso") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("roland alphonso")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1179
+# snips-nlu/spotify-1179
 U: Play Ramakadha by Karl Davydov please
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Karl Davydov" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "ramakadha" && contains(artists, null^^com.spotify:artist("karl davydov")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1181
+# snips-nlu/spotify-1181
 U: Play a tune by Mc Hawking
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "mc hawking") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mc hawking")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1194
+# snips-nlu/spotify-1194
 U: play Bill Evans album The Best Of The 12 Mixes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "bill evans") && id =~ "the best of the 12 mixes" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("bill evans")) && id =~ "the best of the 12 mixes")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1199
+# snips-nlu/spotify-1199
 U: Play Still Life 1 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "still life 1" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "still life 1")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1201
+# snips-nlu/spotify-1201
 U: Play the album Axum
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "axum" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "axum")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1202
+# snips-nlu/spotify-1202
 U: I want to hear the Jody Williams sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "jody williams") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("jody williams")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1203
+# snips-nlu/spotify-1203
 U: Play Ik Hou Van Jou by Elena Temnikova
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Elena Temnikova" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "ik hou van jou" && contains(artists, null^^com.spotify:artist("elena temnikova")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1206
-U: Play some tango.
+# snips-nlu/spotify-1206
+U: Play some tango .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "tango") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "tango") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1208
+# snips-nlu/spotify-1208
 U: play satire music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "satire") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "satire") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1210
+# snips-nlu/spotify-1210
 U: Please play a song by Ahmad Jamal
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "ahmad jamal") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("ahmad jamal")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1214
-U: Play some music by Frayser Boy.
+# snips-nlu/spotify-1214
+U: Play some music by Frayser Boy .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Frayser Boy" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Frayser Boy")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1217
+# snips-nlu/spotify-1217
 U: Please play a song off the Curtis Lee album Rough Diamonds
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "curtis lee") && id =~ "rough diamonds" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("curtis lee")) && id =~ "rough diamonds")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1220
+# snips-nlu/spotify-1220
 U: Play Elastic Love by Junior Marvin
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Junior Marvin" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "elastic love" && contains(artists, null^^com.spotify:artist("junior marvin")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1222
-U: Play These Four Walls by Yummy Bingham.
+# snips-nlu/spotify-1222
+U: Play These Four Walls by Yummy Bingham .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "these four walls" && contains~(artists, "yummy bingham") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "these four walls" && contains(artists, null^^com.spotify:artist("yummy bingham")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1225
+# snips-nlu/spotify-1225
 U: Can I listen to Dj Vibe's top 10?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "dj vibe") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("dj vibe")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1227
+# snips-nlu/spotify-1227
 U: Lets hear some booty bass
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "booty bass") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "booty bass") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1235
+# snips-nlu/spotify-1235
 U: Play some House music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "house") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "house") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1237
+# snips-nlu/spotify-1237
 U: Play me some Goa
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "goa") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "goa") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1246
+# snips-nlu/spotify-1246
 U: play Joshua Homme Belle And Sebastian Write About Love
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "joshua homme") && id =~ "belle and sebastian write about love" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("joshua homme")) && id =~ "belle and sebastian write about love")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1248
+# snips-nlu/spotify-1248
 U: Can you play a song off an album by Shirley Horn
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "shirley horn") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("shirley horn")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1253
+# snips-nlu/spotify-1253
 U: Play me a popular song by Koichi Domoto
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "koichi domoto") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("koichi domoto")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1254
+# snips-nlu/spotify-1254
 U: Play Saturday Nights & Sunday Mornings
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "saturday nights & sunday mornings" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "saturday nights & sunday mornings")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1255
+# snips-nlu/spotify-1255
 U: Play the album Have Another Ball
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "have another ball" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "have another ball")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1260
+# snips-nlu/spotify-1260
 U: play Neutrons  by Seun Kuti
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "neutrons" && contains~(artists, "seun kuti") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "neutrons" && contains(artists, null^^com.spotify:artist("seun kuti")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1262
+# snips-nlu/spotify-1262
 U: Play the album Will Rap Over Hard Rock For Food
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "will rap over hard rock for food" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "will rap over hard rock for food")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1263
+# snips-nlu/spotify-1263
 U: Play Donna Summer
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Donna Summer" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Donna Summer")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1270
-U: Play music by Raheem Devaughn.
+# snips-nlu/spotify-1270
+U: Play music by Raheem Devaughn .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Raheem Devaughn" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Raheem Devaughn")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1277
-U: Play the top caleigh peters.
+# snips-nlu/spotify-1277
+U: Play the top caleigh peters .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "caleigh peters") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("caleigh peters")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1278
+# snips-nlu/spotify-1278
 U: Play new Teo Macero
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "teo macero") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("teo macero")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1285
-U: I want to listen to Merrily We Roll Along by Marko Desantis.
+# snips-nlu/spotify-1285
+U: I want to listen to Merrily We Roll Along by Marko Desantis .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Marko Desantis" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "merrily we roll along" && contains(artists, null^^com.spotify:artist("marko desantis")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1288
+# snips-nlu/spotify-1288
 U: Play any song from Rebecca Hewitt
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "rebecca hewitt") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("rebecca hewitt")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1289
-U: Play the Mister Music Man by Gene De Paul.
+# snips-nlu/spotify-1289
+U: Play the Mister Music Man by Gene De Paul .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Gene De Paul" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "mister music man" && contains(artists, null^^com.spotify:artist("gene de paul")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1290
-U: Let me hear the top album by the artist, Skin.
+# snips-nlu/spotify-1290
+U: Let me hear the top album by the artist, Skin .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains~(artists, "skin") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("skin")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1291
+# snips-nlu/spotify-1291
 U: Play Harel Skaat
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Harel Skaat" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Harel Skaat")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1295
+# snips-nlu/spotify-1295
 U: play the track Asleep In The Deep
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "asleep in the deep")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1302
+# snips-nlu/spotify-1302
 U: Play teri meri by Josh White
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Josh White" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "teri meri" && contains(artists, null^^com.spotify:artist("josh white")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1309
+# snips-nlu/spotify-1309
 U: play Isham Jones
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Isham Jones" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Isham Jones")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1310
+# snips-nlu/spotify-1310
 U: Can you play me some britpop music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "britpop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "britpop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1319
+# snips-nlu/spotify-1319
 U: Play top-50 Peter Frampton songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "peter frampton") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("peter frampton")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1323
+# snips-nlu/spotify-1323
 U: play Tom Baxter tracks
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Tom Baxter" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Tom Baxter")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1333
+# snips-nlu/spotify-1333
 U: Play music by Daddy Yankee
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Daddy Yankee" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Daddy Yankee")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1335
+# snips-nlu/spotify-1335
 U: Play me track September, Gouden Roos by artist daedelus
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "daedelus") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "september, gouden roos" && contains(artists, null^^com.spotify:artist("daedelus")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1339
+# snips-nlu/spotify-1339
 U: Please anything good by Chieko Ochi
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "chieko ochi") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("chieko ochi")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1341
-U: Play Apbl98 by Alden Penner.
+# snips-nlu/spotify-1341
+U: Play Apbl98 by Alden Penner .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "apbl98" && contains~(artists, "alden penner") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "apbl98" && contains(artists, null^^com.spotify:artist("alden penner")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1345
-U: Play Verjamem track by Hong Junyang.
+# snips-nlu/spotify-1345
+U: Play Verjamem track by Hong Junyang .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "hong junyang") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "verjamem" && contains(artists, null^^com.spotify:artist("hong junyang")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1346
-U: Play music by Otis Redding.
+# snips-nlu/spotify-1346
+U: Play music by Otis Redding .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Otis Redding" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Otis Redding")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1351
+# snips-nlu/spotify-1351
 U: Play me a song by Saki Nakajima
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "saki nakajima") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("saki nakajima")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1353
+# snips-nlu/spotify-1353
 U: Play a top track by Janamanchi Seshadri Sarma
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "janamanchi seshadri sarma") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("janamanchi seshadri sarma")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1355
-U: Play music by Sha Money Xl sort by good.
+# snips-nlu/spotify-1355
+U: Play music by Sha Money Xl sort by good .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "sha money xl") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("sha money xl")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1357
+# snips-nlu/spotify-1357
 U: Play Someday Soon by fiona
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "fiona" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "someday soon" && contains(artists, null^^com.spotify:artist("fiona")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1359
-U: Play tuomas holopainen's The 21 Project.
+# snips-nlu/spotify-1359
+U: Play tuomas holopainen's The 21 Project .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "tuomas holopainen") && id =~ "the 21 project" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("tuomas holopainen")) && id =~ "the 21 project")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1361
-U: Play a top twenty sort by Akinyele.
+# snips-nlu/spotify-1361
+U: Play a top twenty sort by Akinyele .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "akinyele") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("akinyele")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1368
-U: Play Rob Mills album The Golden Archipelago.
+# snips-nlu/spotify-1368
+U: Play Rob Mills album The Golden Archipelago .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "rob mills") && id =~ "the golden archipelago" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("rob mills")) && id =~ "the golden archipelago")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1375
+# snips-nlu/spotify-1375
 U: play Glenn Yarbrough tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Glenn Yarbrough" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Glenn Yarbrough")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1377
+# snips-nlu/spotify-1377
 U: Play me a tune by Mick Brown
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "mick brown") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mick brown")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1378
+# snips-nlu/spotify-1378
 U: play The Insoc Ep
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the insoc ep" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the insoc ep")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1380
+# snips-nlu/spotify-1380
 U: I need to hear the new Kevin Fowler album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "kevin fowler") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("kevin fowler")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1383
-U: Play Stefon Harris's song.
+# snips-nlu/spotify-1383
+U: Play Stefon Harris's song .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "stefon harris") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("stefon harris")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1386
-U: Play Step Up Your Game by Marc Cohn.
+# snips-nlu/spotify-1386
+U: Play Step Up Your Game by Marc Cohn .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "step up your game" && contains~(artists, "marc cohn") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "step up your game" && contains(artists, null^^com.spotify:artist("marc cohn")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1390
-U: Play the top five songs from Robert Lockwood Junior.
+# snips-nlu/spotify-1390
+U: Play the top five songs from Robert Lockwood Junior .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "robert lockwood junior") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("robert lockwood junior")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1391
+# snips-nlu/spotify-1391
 U: Play some latin music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "latin") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "latin") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1393
+# snips-nlu/spotify-1393
 U: Play me Hier Encore by greydon square
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "greydon square" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "hier encore" && contains(artists, null^^com.spotify:artist("greydon square")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1396
-U: Play Dj Shadow's A Love Hate Masquerade.
+# snips-nlu/spotify-1396
+U: Play Dj Shadow's A Love Hate Masquerade .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "dj shadow") && id =~ "a love hate masquerade" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("dj shadow")) && id =~ "a love hate masquerade")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1397
+# snips-nlu/spotify-1397
 U: play Seven Steps To Heaven by Wikluh Sky
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Wikluh Sky" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "seven steps to heaven" && contains(artists, null^^com.spotify:artist("wikluh sky")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1398
-U: Play some music from Victor Kunonga.
+# snips-nlu/spotify-1398
+U: Play some music from Victor Kunonga .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Victor Kunonga" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Victor Kunonga")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1401
+# snips-nlu/spotify-1401
 U: Play March Of The Soviet Tankmen from Gloria Gaither
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Gloria Gaither" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "march of the soviet tankmen" && contains(artists, null^^com.spotify:artist("gloria gaither")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1402
+# snips-nlu/spotify-1402
 U: Play music from the album Evolution Of A Man by Joey Ramone
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "evolution of a man" && contains~(artists, "joey ramone") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "evolution of a man" && contains(artists, null^^com.spotify:artist("joey ramone")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1407
-U: Play some Joeri Basjmet.
+# snips-nlu/spotify-1407
+U: Play some Joeri Basjmet .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Joeri Basjmet" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Joeri Basjmet")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1408
+# snips-nlu/spotify-1408
 U: Play Elliot Easton's album Beautiful
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "elliot easton") && id =~ "beautiful" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("elliot easton")) && id =~ "beautiful")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1416
-U: Play How Does It Work by Helen Carter.
+# snips-nlu/spotify-1416
+U: Play How Does It Work by Helen Carter .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "how does it work" && contains~(artists, "helen carter") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "how does it work" && contains(artists, null^^com.spotify:artist("helen carter")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1418
+# snips-nlu/spotify-1418
 U: I want to hear something from Post-punk Revival
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "post-punk revival") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "post-punk revival") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1419
+# snips-nlu/spotify-1419
 U: Play music from the artist Joe Sample
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Joe Sample" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Joe Sample")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1420
+# snips-nlu/spotify-1420
 U: Play Dave Joyal
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Dave Joyal" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Dave Joyal")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1422
+# snips-nlu/spotify-1422
 U: I want to hear something from the top-fifty by Jose Pasillas
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "jose pasillas") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jose pasillas")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1426
+# snips-nlu/spotify-1426
 U: play primus 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "primus") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "primus") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1433
+# snips-nlu/spotify-1433
 U: play Realization by Randy Jackson
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "realization" && contains~(artists, "randy jackson") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "realization" && contains(artists, null^^com.spotify:artist("randy jackson")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1434
+# snips-nlu/spotify-1434
 U: Please play some Bill Evans music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Bill Evans" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Bill Evans")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1436
+# snips-nlu/spotify-1436
 U: Can you play the greatest songs by Mauro Picotto
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "mauro picotto") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("mauro picotto")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1437
+# snips-nlu/spotify-1437
 U: Play music by Deenanath Mangeshkar
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Deenanath Mangeshkar" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Deenanath Mangeshkar")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1439
+# snips-nlu/spotify-1439
 U: Play track Real Talk
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "real talk")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1443
+# snips-nlu/spotify-1443
 U: listen to Vertexguy track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "vertexguy") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("vertexguy")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1444
+# snips-nlu/spotify-1444
 U: Play the most popular stuff by Tina Dico
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "tina dico") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tina dico")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1450
+# snips-nlu/spotify-1450
 U: Can you play some music from my road trip album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album() => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album() => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1453
-U: Play Oj, Jelena, Jelena, Jabuka Zelena by Ler Lalonde.
+# snips-nlu/spotify-1453
+U: Play Oj, Jelena, Jelena, Jabuka Zelena by Ler Lalonde .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ler Lalonde" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "oj, jelena, jelena, jabuka zelena" && contains(artists, null^^com.spotify:artist("ler lalonde")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1458
+# snips-nlu/spotify-1458
 U: Play Pledge by Markus Grosskopf
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "pledge" && contains~(artists, "markus grosskopf") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "pledge" && contains(artists, null^^com.spotify:artist("markus grosskopf")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1463
-U: Play some James Cleveland.
+# snips-nlu/spotify-1463
+U: Play some James Cleveland .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "James Cleveland" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "James Cleveland")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1465
+# snips-nlu/spotify-1465
 U: play the album Wayning Moments by Rabbit Brown
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "wayning moments" && contains~(artists, "rabbit brown") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "wayning moments" && contains(artists, null^^com.spotify:artist("rabbit brown")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1473
+# snips-nlu/spotify-1473
 U: play some Mike Porcaro
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Mike Porcaro" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Mike Porcaro")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1476
+# snips-nlu/spotify-1476
 U: Play music from Hide
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Hide" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Hide")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1480
+# snips-nlu/spotify-1480
 U: Play me a track by Steve Souza
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "steve souza") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("steve souza")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1483
+# snips-nlu/spotify-1483
 U: Play me a song by Hank Thompson from Moa Anbessa
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "hank thompson") && id =~ "moa anbessa" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("hank thompson")) && id =~ "moa anbessa")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1485
+# snips-nlu/spotify-1485
 U: Play Me Against The World from Glukoza
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "me against the world" && contains~(artists, "glukoza") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "me against the world" && contains(artists, null^^com.spotify:artist("glukoza")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1491
+# snips-nlu/spotify-1491
 U: play Innovations by Kokia
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "innovations" && contains~(artists, "kokia") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "innovations" && contains(artists, null^^com.spotify:artist("kokia")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1493
+# snips-nlu/spotify-1493
 U: play Fernando Olvera
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Fernando Olvera" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Fernando Olvera")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1494
+# snips-nlu/spotify-1494
 U: Can you play something off Johan Larsson's Travelers And Thieves
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "johan larsson") && id =~ "travelers and thieves" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("johan larsson")) && id =~ "travelers and thieves")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1495
+# snips-nlu/spotify-1495
 U: list to the most popular Muireann Nic Amhlaoibh song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "muireann nic amhlaoibh") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("muireann nic amhlaoibh")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1500
+# snips-nlu/spotify-1500
 U: Play the song Long Live Love
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "long live love")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1502
+# snips-nlu/spotify-1502
 U: Play the top of emil de cou
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "emil de cou") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("emil de cou")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1509
+# snips-nlu/spotify-1509
 U: Play instrumental pop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "instrumental pop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "instrumental pop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1510
-U: Play some Hong Junyang.
+# snips-nlu/spotify-1510
+U: Play some Hong Junyang .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Hong Junyang" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Hong Junyang")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1511
-U: Play mere lapsed by Marilyn Moore.
+# snips-nlu/spotify-1511
+U: Play mere lapsed by Marilyn Moore .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Marilyn Moore" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "mere lapsed" && contains(artists, null^^com.spotify:artist("marilyn moore")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1517
+# snips-nlu/spotify-1517
 U: play music by Rodney Whitaker
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Rodney Whitaker" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Rodney Whitaker")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1519
+# snips-nlu/spotify-1519
 U: play the latest Thelma Aoyama
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "thelma aoyama") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("thelma aoyama")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1520
-U: Play some music by Karl Blau.
+# snips-nlu/spotify-1520
+U: Play some music by Karl Blau .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Karl Blau" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Karl Blau")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1530
+# snips-nlu/spotify-1530
 U: Play Songs Of Heaven by ami koshimizu
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "songs of heaven" && contains~(artists, "ami koshimizu") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "songs of heaven" && contains(artists, null^^com.spotify:artist("ami koshimizu")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1541
+# snips-nlu/spotify-1541
 U: Play music by artist mark ashley
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "mark ashley" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "mark ashley")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1542
-U: Play the top Maynard James Keenan.
+# snips-nlu/spotify-1542
+U: Play the top Maynard James Keenan .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "maynard james keenan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("maynard james keenan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1544
+# snips-nlu/spotify-1544
 U: Play the most popular song by espen lind
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "espen lind") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("espen lind")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1545
+# snips-nlu/spotify-1545
 U: Play Yuauea by Rick Ross
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "yuauea" && contains~(artists, "rick ross") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "yuauea" && contains(artists, null^^com.spotify:artist("rick ross")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1546
-U: Play The Tyranny Of Distance by Willy Mason.
+# snips-nlu/spotify-1546
+U: Play The Tyranny Of Distance by Willy Mason .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the tyranny of distance" && contains~(artists, "willy mason") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the tyranny of distance" && contains(artists, null^^com.spotify:artist("willy mason")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1551
+# snips-nlu/spotify-1551
 U: Play Chad I Ginsburg
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Chad I Ginsburg" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Chad I Ginsburg")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1557
+# snips-nlu/spotify-1557
 U: Play the song Drifting On A Reed by Bobby G
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "bobby g") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "drifting on a reed" && contains(artists, null^^com.spotify:artist("bobby g")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1562
+# snips-nlu/spotify-1562
 U: Play a tune or two from Kansas City, Missouri
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "kansas city, missouri") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("kansas city, missouri")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1565
+# snips-nlu/spotify-1565
 U: play To Be Still
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "to be still" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "to be still")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1568
+# snips-nlu/spotify-1568
 U: play the It Could Only Happen With You album by Lawrence
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "it could only happen with you" && contains~(artists, "lawrence") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "it could only happen with you" && contains(artists, null^^com.spotify:artist("lawrence")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1569
-U: Play Moondog's Chupacabra.
+# snips-nlu/spotify-1569
+U: Play Moondog's Chupacabra .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "moondog") && id =~ "chupacabra" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("moondog")) && id =~ "chupacabra")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1570
+# snips-nlu/spotify-1570
 U: I'd like to hear some trip-hop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "trip-hop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "trip-hop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1576
+# snips-nlu/spotify-1576
 U: play a sound track by Vegard Sverre Tveitan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "vegard sverre tveitan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("vegard sverre tveitan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1578
+# snips-nlu/spotify-1578
 U: I want to hear the album Suites & Sweets
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "suites & sweets" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "suites & sweets")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1580
+# snips-nlu/spotify-1580
 U: Open The Second Adventure album by Hans Nilsson
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the second adventure" && contains~(artists, "hans nilsson") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the second adventure" && contains(artists, null^^com.spotify:artist("hans nilsson")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1582
+# snips-nlu/spotify-1582
 U: I want to hear This Is The Night from Proof
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Proof" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "this is the night" && contains(artists, null^^com.spotify:artist("proof")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1584
+# snips-nlu/spotify-1584
 U: Play me a song by Michael Diamond
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "michael diamond") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("michael diamond")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1588
+# snips-nlu/spotify-1588
 U: Play Dawn Richard song White Summer
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "dawn richard") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("dawn richard")) && id =~ "white summer")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1592
+# snips-nlu/spotify-1592
 U: play newest Robert Palmer sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "robert palmer") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("robert palmer")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1595
-U: Play some Dj Qbert.
+# snips-nlu/spotify-1595
+U: Play some Dj Qbert .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Dj Qbert" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Dj Qbert")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1596
+# snips-nlu/spotify-1596
 U: Play Supernaut by Armand Van Helden
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Armand Van Helden" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "supernaut" && contains(artists, null^^com.spotify:artist("armand van helden")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1599
+# snips-nlu/spotify-1599
 U: Play got to be free by Madeleine Peyroux
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Madeleine Peyroux" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "got to be free" && contains(artists, null^^com.spotify:artist("madeleine peyroux")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1600
+# snips-nlu/spotify-1600
 U: Play music in the genre soundtrack
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "soundtrack") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "soundtrack") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1602
+# snips-nlu/spotify-1602
 U: Play music from Carina Round
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Carina Round" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Carina Round")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1604
+# snips-nlu/spotify-1604
 U: Play a song off The Best Of Siouxsie & The Banshees by Faustino Oramas
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the best of siouxsie & the banshees" && contains~(artists, "faustino oramas") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the best of siouxsie & the banshees" && contains(artists, null^^com.spotify:artist("faustino oramas")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1605
-U: Play the album, Dance Hall At Louse Point.
+# snips-nlu/spotify-1605
+U: Play the album, Dance Hall At Louse Point .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "dance hall at louse point" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "dance hall at louse point")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1606
+# snips-nlu/spotify-1606
 U: play Lighter by Pamela Jintana Racine
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Pamela Jintana Racine" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "lighter" && contains(artists, null^^com.spotify:artist("pamela jintana racine")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1612
+# snips-nlu/spotify-1612
 U: I'd like to hear Helen Baylor
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Helen Baylor" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Helen Baylor")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1614
-U: Play Kool Keith Presents Thee Undatakerz by John Mccrea.
+# snips-nlu/spotify-1614
+U: Play Kool Keith Presents Thee Undatakerz by John Mccrea .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "kool keith presents thee undatakerz" && contains~(artists, "john mccrea") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "kool keith presents thee undatakerz" && contains(artists, null^^com.spotify:artist("john mccrea")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1629
-U: Play Burhøns by Ernie C.
+# snips-nlu/spotify-1629
+U: Play Burhøns by Ernie C .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "burhøns" && contains~(artists, "ernie c") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "burhøns" && contains(artists, null^^com.spotify:artist("ernie c")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1636
+# snips-nlu/spotify-1636
 U: I want to listen to some Aaliyah
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Aaliyah" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Aaliyah")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1641
+# snips-nlu/spotify-1641
 U: Play drum & bass music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "drum & bass") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "drum & bass") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1652
+# snips-nlu/spotify-1652
 U: I want to hear some The Roches
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the roches" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the roches")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1656
+# snips-nlu/spotify-1656
 U: play Soheila Zaland
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Soheila Zaland" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Soheila Zaland")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1662
+# snips-nlu/spotify-1662
 U: I need some ambient music. 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "ambient") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "ambient") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1663
+# snips-nlu/spotify-1663
 U: Play a song by Nash The Slash
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "nash the slash") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("nash the slash")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1666
+# snips-nlu/spotify-1666
 U: play the best Elizaveta Khripounova
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "elizaveta khripounova") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("elizaveta khripounova")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1669
+# snips-nlu/spotify-1669
 U: Play Crazy=genius by The Alchemist
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "The Alchemist" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "crazy=genius" && contains(artists, null^^com.spotify:artist("the alchemist")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1670
+# snips-nlu/spotify-1670
 U: Can I listen to merengue style music?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "merengue") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "merengue") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1675
+# snips-nlu/spotify-1675
 U: Play Soldier Boy from Melody Gardot
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Melody Gardot" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "soldier boy" && contains(artists, null^^com.spotify:artist("melody gardot")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1678
+# snips-nlu/spotify-1677
+U: Please play Bitch Please Ii
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "bitch please ii")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-1678
 U: Could you play the album B Men Gahō by Nathaniel Shilkret
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "b men gahō" && contains~(artists, "nathaniel shilkret") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "b men gahō" && contains(artists, null^^com.spotify:artist("nathaniel shilkret")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1680
+# snips-nlu/spotify-1680
 U: play robin hood and the bishop of hereford by Jon Mayer
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Jon Mayer" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "robin hood and the bishop of hereford" && contains(artists, null^^com.spotify:artist("jon mayer")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1686
+# snips-nlu/spotify-1686
 U: Play the song American Patrol by lauryn hill
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "lauryn hill") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "american patrol" && contains(artists, null^^com.spotify:artist("lauryn hill")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1688
-U: Play Junun by Noam Kaniel.
+# snips-nlu/spotify-1688
+U: Play Junun by Noam Kaniel .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "junun" && contains~(artists, "noam kaniel") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "junun" && contains(artists, null^^com.spotify:artist("noam kaniel")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1689
+# snips-nlu/spotify-1689
 U: Please play anything by george formby jr
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "george formby jr" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "george formby jr")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1698
-U: Play El Cant Dels Ocells by vini lopez.
+# snips-nlu/spotify-1698
+U: Play El Cant Dels Ocells by vini lopez .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "vini lopez" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "el cant dels ocells" && contains(artists, null^^com.spotify:artist("vini lopez")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1706
-U: Play the album Remember Shakti – The Believer.
+# snips-nlu/spotify-1706
+U: Play the album Remember Shakti – The Believer .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "remember shakti – the believer" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "remember shakti – the believer")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1712
+# snips-nlu/spotify-1712
 U: Play any track by Flame
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "flame") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("flame")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1720
+# snips-nlu/spotify-1720
 U: Play Lenny Kaye music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Lenny Kaye" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Lenny Kaye")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1721
+# snips-nlu/spotify-1721
 U: play Ngola Ritmos top-ten songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "ngola ritmos") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ngola ritmos")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1725
-U: Play the album Cara De Dios.
+# snips-nlu/spotify-1725
+U: Play the album Cara De Dios .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "cara de dios" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "cara de dios")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1727
+# snips-nlu/spotify-1727
 U: Play Adieu by Al Arsenault
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Al Arsenault" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "adieu" && contains(artists, null^^com.spotify:artist("al arsenault")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1728
+# snips-nlu/spotify-1728
 U: Play Expresión from Mickey Finn
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "expresión" && contains~(artists, "mickey finn") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "expresión" && contains(artists, null^^com.spotify:artist("mickey finn")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1729
+# snips-nlu/spotify-1729
 U: play music by Bonobo
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Bonobo" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Bonobo")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1732
+# snips-nlu/spotify-1732
 U: Play Miami 2017 by Rodney Whitaker
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Rodney Whitaker" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "miami 2017" && contains(artists, null^^com.spotify:artist("rodney whitaker")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1734
+# snips-nlu/spotify-1734
 U: Can you play Halloween by Ajinoam Nini
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ajinoam Nini" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "halloween" && contains(artists, null^^com.spotify:artist("ajinoam nini")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1736
+# snips-nlu/spotify-1736
 U: play Angelo Amorevoli
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Angelo Amorevoli" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Angelo Amorevoli")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1740
+# snips-nlu/spotify-1740
 U: Play artist Vlada Divljan from something he did that is good
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "vlada divljan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("vlada divljan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1741
+# snips-nlu/spotify-1741
 U: Play the track Pocahontas John Farnham
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "john farnham") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "pocahontas" && contains(artists, null^^com.spotify:artist("john farnham")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1742
+# snips-nlu/spotify-1742
 U: play some popular bryan gregory songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "bryan gregory") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bryan gregory")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1747
+# snips-nlu/spotify-1747
 U: Play some Techno
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "techno") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "techno") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1749
+# snips-nlu/spotify-1749
 U: play Fereydoun Farrokhzad best track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "fereydoun farrokhzad") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fereydoun farrokhzad")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1750
+# snips-nlu/spotify-1750
 U: Can I listen to music from the Easy Listening genre?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "easy listening") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "easy listening") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1752
+# snips-nlu/spotify-1752
 U: play the top-20 Rita Macneil songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "rita macneil") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("rita macneil")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1755
-U: Play a sound track by Mac Dre.
+# snips-nlu/spotify-1755
+U: Play a sound track by Mac Dre .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "mac dre") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mac dre")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1759
-U: Play the best music from Klaus Badelt.
+# snips-nlu/spotify-1759
+U: Play the best music from Klaus Badelt .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "klaus badelt") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("klaus badelt")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1766
-U: I'd like to hear the last song fro Willa Ford.
+# snips-nlu/spotify-1766
+U: I'd like to hear the last song fro Willa Ford .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "willa ford") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("willa ford")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1771
+# snips-nlu/spotify-1771
 U: play Techno music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "techno") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "techno") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1772
+# snips-nlu/spotify-1772
 U: play shara worden
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "shara worden" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "shara worden")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1790
+# snips-nlu/spotify-1790
 U: play a Keith Richards album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "keith richards") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("keith richards")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1791
+# snips-nlu/spotify-1791
 U: Play the track Fight On, State by Yuvan Shankar Raja
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "yuvan shankar raja") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "fight on, state" && contains(artists, null^^com.spotify:artist("yuvan shankar raja")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1794
+# snips-nlu/spotify-1794
 U: Play Moris Tepper
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Moris Tepper" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Moris Tepper")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1797
-U: Play Entre Raices Y Antenas by Lynn & Wade Llp.
+# snips-nlu/spotify-1797
+U: Play Entre Raices Y Antenas by Lynn & Wade Llp .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "entre raices y antenas" && contains~(artists, "lynn & wade llp") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "entre raices y antenas" && contains(artists, null^^com.spotify:artist("lynn & wade llp")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1798
+# snips-nlu/spotify-1798
 U: Play some acapella music 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "acapella") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "acapella") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1799
+# snips-nlu/spotify-1799
 U: Play a Paolo Gregoletto song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "paolo gregoletto") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("paolo gregoletto")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1806
+# snips-nlu/spotify-1806
 U: Play Who Knows Where The Time Goes? by Grigory Leps
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Grigory Leps" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "who knows where the time goes" && contains(artists, null^^com.spotify:artist("grigory leps")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1812
+# snips-nlu/spotify-1812
 U: Play Elitsa Todorova music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Elitsa Todorova" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Elitsa Todorova")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1815
+# snips-nlu/spotify-1815
 U: Please play some Black Metal music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "black metal") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "black metal") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1822
-U: I want to hear Aki Nawaz, play the song fair annie.
+# snips-nlu/spotify-1822
+U: I want to hear Aki Nawaz, play the song fair annie .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "aki nawaz") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("aki nawaz")) && id =~ "fair annie")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1826
+# snips-nlu/spotify-1826
 U: Play some chanson style music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "chanson") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "chanson") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1830
+# snips-nlu/spotify-1830
 U: Play a track by Titiyo
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "titiyo") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("titiyo")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1833
+# snips-nlu/spotify-1833
 U: Play Is This My World? by Leo Arnaud
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "is this my world" && contains~(artists, "leo arnaud") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "is this my world" && contains(artists, null^^com.spotify:artist("leo arnaud")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1834
-U: Play While The Gate Is Open.
+# snips-nlu/spotify-1834
+U: Play While The Gate Is Open .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "while the gate is open" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "while the gate is open")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1836
-U: Play some Rui Da Silva.
+# snips-nlu/spotify-1836
+U: Play some Rui Da Silva .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Rui Da Silva" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Rui Da Silva")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1837
+# snips-nlu/spotify-1837
 U: Play The Cherry-tree Carol by Edwin Mccain
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Edwin Mccain" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "the cherry-tree carol" && contains(artists, null^^com.spotify:artist("edwin mccain")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1840
+# snips-nlu/spotify-1838
+U: Play Tomtegubben Som Hade Snuva
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "tomtegubben som hade snuva")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-1840
 U: Play the song domino by Luca Turilli
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "luca turilli") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "domino" && contains(artists, null^^com.spotify:artist("luca turilli")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1842
+# snips-nlu/spotify-1842
 U: play the newest Martin Solveig sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "martin solveig") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("martin solveig")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1845
+# snips-nlu/spotify-1845
 U: play Mohammed Abdu from top 20
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "mohammed abdu") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("mohammed abdu")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1846
-U: Play the top ten by Andrea Del Rosario.
+# snips-nlu/spotify-1846
+U: Play the top ten by Andrea Del Rosario .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "andrea del rosario") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("andrea del rosario")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1854
-U: Play rie fu music sorted by the best.
+# snips-nlu/spotify-1854
+U: Play rie fu music sorted by the best .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "rie fu") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("rie fu")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1860
+# snips-nlu/spotify-1860
 U: play steve harris False Gestures For A Devious Public album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "steve harris") && id =~ "false gestures for a devious public" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("steve harris")) && id =~ "false gestures for a devious public")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1862
-U: I want to hear a good album from Toni Cottura.
+# snips-nlu/spotify-1862
+U: I want to hear a good album from Toni Cottura .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains~(artists, "toni cottura") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("toni cottura")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1870
+# snips-nlu/spotify-1870
 U: I need some Hardcore Hip Hop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "hardcore hip hop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "hardcore hip hop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1874
+# snips-nlu/spotify-1874
 U: play Dj Ozma top songs
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "dj ozma") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("dj ozma")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1875
-U: PLay a track by deeyah khan.
+# snips-nlu/spotify-1875
+U: PLay a track by deeyah khan .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "deeyah khan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("deeyah khan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1881
-U: Let me hear the Rave Tapes album from Yuki Koyanagi.
+# snips-nlu/spotify-1881
+U: Let me hear the Rave Tapes album from Yuki Koyanagi .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "rave tapes" && contains~(artists, "yuki koyanagi") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "rave tapes" && contains(artists, null^^com.spotify:artist("yuki koyanagi")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1884
+# snips-nlu/spotify-1884
 U: Play the song Two Suns In The Sunset by Airi Suzuki
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "airi suzuki") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "two suns in the sunset" && contains(artists, null^^com.spotify:artist("airi suzuki")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1886
+# snips-nlu/spotify-1886
 U: Play the greatest music by Phoebe Snow
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "phoebe snow") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("phoebe snow")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1896
+# snips-nlu/spotify-1896
 U: Play music off the track Child Maurice
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "child maurice")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1897
+# snips-nlu/spotify-1897
 U: Play me a song from Voices & Images
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "voices & images" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "voices & images")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1901
-U: I'd like to hear a track by Theo Keating.
+# snips-nlu/spotify-1901
+U: I'd like to hear a track by Theo Keating .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "theo keating") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("theo keating")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1910
+# snips-nlu/spotify-1910
 U: play ambient music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "ambient") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "ambient") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1911
+# snips-nlu/spotify-1911
 U: Play the last song by Goldie
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "goldie") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("goldie")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1912
+# snips-nlu/spotify-1912
 U: Play Pride Of The Prairie from Johnny Burke
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Johnny Burke" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "pride of the prairie" && contains(artists, null^^com.spotify:artist("johnny burke")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1914
+# snips-nlu/spotify-1914
 U: Play the song Le Renouveau
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "le renouveau")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1916
+# snips-nlu/spotify-1916
 U: play the latest Thelma Aoyama
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "thelma aoyama") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("thelma aoyama")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1922
+# snips-nlu/spotify-1922
 U: I would like to hear a song by Tim Reynolds
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "tim reynolds") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("tim reynolds")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1928
+# snips-nlu/spotify-1928
 U: Play me Benjamin Kowalewicz's top hits
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "benjamin kowalewicz") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("benjamin kowalewicz")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1930
-U: Play some music by Mark Heard.
+# snips-nlu/spotify-1930
+U: Play some music by Mark Heard .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Mark Heard" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Mark Heard")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1931
+# snips-nlu/spotify-1931
 U: Play Inventions For The New Season
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "inventions for the new season" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "inventions for the new season")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1932
+# snips-nlu/spotify-1932
 U: I want to hear some freestyle music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "freestyle") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "freestyle") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1934
-U: Play sweet shanghai devil by Teddy Diaz.
+# snips-nlu/spotify-1934
+U: Play sweet shanghai devil by Teddy Diaz .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "sweet shanghai devil" && contains~(artists, "teddy diaz") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "sweet shanghai devil" && contains(artists, null^^com.spotify:artist("teddy diaz")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1937
+# snips-nlu/spotify-1937
 U: Play music from negerpunk
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "negerpunk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "negerpunk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1938
+# snips-nlu/spotify-1938
 U: play music by Odd Nosdam
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Odd Nosdam" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Odd Nosdam")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1939
-U: Play music by Susumu Hirasawa.
+# snips-nlu/spotify-1939
+U: Play music by Susumu Hirasawa .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Susumu Hirasawa" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Susumu Hirasawa")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1945
+# snips-nlu/spotify-1945
 U: I want to hear music from the Lotus Flower album by Andy Mccoy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "lotus flower" && contains~(artists, "andy mccoy") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "lotus flower" && contains(artists, null^^com.spotify:artist("andy mccoy")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1947
+# snips-nlu/spotify-1947
 U: Play the song Jingle Bells
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "jingle bells")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1948
+# snips-nlu/spotify-1948
 U: Please play me some Satire music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "satire") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "satire") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1950
-U: Let me listen to The Music Of Nature album by Paul Draper.
+# snips-nlu/spotify-1950
+U: Let me listen to The Music Of Nature album by Paul Draper .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the music of nature" && contains~(artists, "paul draper") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the music of nature" && contains(artists, null^^com.spotify:artist("paul draper")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1957
+# snips-nlu/spotify-1957
 U: Play the music of Aphex Twin's good Album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains~(artists, "aphex twin") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("aphex twin")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1967
+# snips-nlu/spotify-1967
 U: Play the last Jonny Wickersham song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "jonny wickersham") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jonny wickersham")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1971
+# snips-nlu/spotify-1971
 U: Play Hættuleg Hljómsveit & Glæpakvendið Stella by Kaori Iida
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "hættuleg hljómsveit & glæpakvendið stella" && contains~(artists, "kaori iida") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "hættuleg hljómsveit & glæpakvendið stella" && contains(artists, null^^com.spotify:artist("kaori iida")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1973
+# snips-nlu/spotify-1973
 U: Play the track Goodbye Alexander, Goodbye Honey Boy from Ehsaan Noorani
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "ehsaan noorani") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "goodbye alexander, goodbye honey boy" && contains(artists, null^^com.spotify:artist("ehsaan noorani")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1976
+# snips-nlu/spotify-1976
 U: I want to hear secrets on parade from Tommy Walter
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "secrets on parade" && contains~(artists, "tommy walter") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "secrets on parade" && contains(artists, null^^com.spotify:artist("tommy walter")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1979
+# snips-nlu/spotify-1979
 U: play music by Christian Bautista
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Christian Bautista" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Christian Bautista")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1984
-U: Let me hear the Live From The Ghetto album by Beau Jocque.
+# snips-nlu/spotify-1984
+U: Let me hear the Live From The Ghetto album by Beau Jocque .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "live from the ghetto" && contains~(artists, "beau jocque") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "live from the ghetto" && contains(artists, null^^com.spotify:artist("beau jocque")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1985
+# snips-nlu/spotify-1985
 U: Play Turbulence Wild Streetdanz from Jeff Buckley
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "turbulence wild streetdanz" && contains~(artists, "jeff buckley") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "turbulence wild streetdanz" && contains(artists, null^^com.spotify:artist("jeff buckley")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1987
+# snips-nlu/spotify-1987
 U: Play the greatest Ricky Bell music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "ricky bell") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("ricky bell")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1989
+# snips-nlu/spotify-1989
 U: Play music by Sarah Connor
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Sarah Connor" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Sarah Connor")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1991
+# snips-nlu/spotify-1991
 U: Play music from Alison Sudol
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Alison Sudol" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Alison Sudol")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-1992
-U: Play Odessa by Maartin Allcock.
+# snips-nlu/spotify-1992
+U: Play Odessa by Maartin Allcock .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Maartin Allcock" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "odessa" && contains(artists, null^^com.spotify:artist("maartin allcock")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1995
+# snips-nlu/spotify-1995
 U: Play the most popular track from Valery Alexandrovich Kipelov
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "valery alexandrovich kipelov") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("valery alexandrovich kipelov")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1999
+# snips-nlu/spotify-1999
 U: play Roy Orbison tunes now
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Roy Orbison" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Roy Orbison")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2003
+# snips-nlu/spotify-2003
 U: is there something new you can play by Lola Monroe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "lola monroe") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("lola monroe")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2004
+# snips-nlu/spotify-2004
 U: I want to hear something from Post-punk Revival
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "post-punk revival") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "post-punk revival") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2007
-U: Play the top music from Epic Mazur.
+# snips-nlu/spotify-2007
+U: Play the top music from Epic Mazur .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "epic mazur") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("epic mazur")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2008
-U: I want to hear track 34.
+# snips-nlu/spotify-2008
+U: I want to hear track 34 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "34")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2011
-U: Let's listen to Matthew Shipp.
+# snips-nlu/spotify-2011
+U: Let's listen to Matthew Shipp .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Matthew Shipp" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Matthew Shipp")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2013
+# snips-nlu/spotify-2013
 U: put on a Serge Robert track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "serge robert") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("serge robert")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2014
+# snips-nlu/spotify-2014
 U: Play some Hridaynath Mangeshkar
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Hridaynath Mangeshkar" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Hridaynath Mangeshkar")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2023
-U: Let me hear Wintley Phipps top fifty album.
+# snips-nlu/spotify-2023
+U: Let me hear Wintley Phipps top fifty album .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains~(artists, "wintley phipps") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("wintley phipps")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2025
+# snips-nlu/spotify-2025
 U: play me some Dom Pachino
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Dom Pachino" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Dom Pachino")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2030
+# snips-nlu/spotify-2030
 U: Put The Silent Enigma album by Yoko Kanno
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the silent enigma" && contains~(artists, "yoko kanno") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the silent enigma" && contains(artists, null^^com.spotify:artist("yoko kanno")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2031
+# snips-nlu/spotify-2031
 U: Please play Every Woman In Me
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "every woman in me" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "every woman in me")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2034
+# snips-nlu/spotify-2034
 U: play In The Disco by Danny Hutton
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Danny Hutton" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "in the disco" && contains(artists, null^^com.spotify:artist("danny hutton")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2035
+# snips-nlu/spotify-2035
 U: Play some lyn paul
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "lyn paul" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "lyn paul")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2036
-U: Play Ocean Beach from paul delay.
+# snips-nlu/spotify-2036
+U: Play Ocean Beach from paul delay .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "ocean beach" && contains~(artists, "paul delay") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "ocean beach" && contains(artists, null^^com.spotify:artist("paul delay")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2045
+# snips-nlu/spotify-2038
+U: I would like to hear The Worst Is Yet To Come .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "the worst is yet to come")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-2045
 U: Play some klezmer fiddle
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "klezmer fiddle") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "klezmer fiddle") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2048
+# snips-nlu/spotify-2046
+U: Play the Broom Of The Cowdenknowes .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "broom of the cowdenknowes")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-2048
 U: Can you play some decent work by Timour Moutsouraev?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Timour Moutsouraev" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Timour Moutsouraev")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2050
+# snips-nlu/spotify-2050
 U: most popular song of taco ockerse
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "taco ockerse") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("taco ockerse")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2051
+# snips-nlu/spotify-2051
 U: Play Tennessee Saturday Night by Mr. Porter
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Mr. Porter" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "tennessee saturday night" && contains(artists, null^^com.spotify:artist("mr. porter")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2055
+# snips-nlu/spotify-2055
 U: I want to hear the last album from Frank Iero
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains~(artists, "frank iero") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("frank iero")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2059
+# snips-nlu/spotify-2059
 U: Can you play some music by Abatte Barihun?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Abatte Barihun" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Abatte Barihun")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2060
-U: I want to hear Shooby Taylor's Tearing Up The Album Charts.
+# snips-nlu/spotify-2060
+U: I want to hear Shooby Taylor's Tearing Up The Album Charts .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "shooby taylor") && id =~ "tearing up the album charts" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("shooby taylor")) && id =~ "tearing up the album charts")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2062
+# snips-nlu/spotify-2062
 U: play something new by tansen
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "tansen") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tansen")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2066
-U: Play some Grand Puba.
+# snips-nlu/spotify-2066
+U: Play some Grand Puba .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Grand Puba" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Grand Puba")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2067
-U: Play the top fifty by Kate Bush.
+# snips-nlu/spotify-2067
+U: Play the top fifty by Kate Bush .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "kate bush") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("kate bush")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2068
+# snips-nlu/spotify-2068
 U: Play the Stephen Stills album Verge
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "stephen stills") && id =~ "verge" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("stephen stills")) && id =~ "verge")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2069
+# snips-nlu/spotify-2069
 U: I need some Hardcore Hip Hop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "hardcore hip hop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "hardcore hip hop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2071
-U: Play Gaston by Daniel De Los Reyes.
+# snips-nlu/spotify-2071
+U: Play Gaston by Daniel De Los Reyes .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Daniel De Los Reyes" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "gaston" && contains(artists, null^^com.spotify:artist("daniel de los reyes")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2072
+# snips-nlu/spotify-2072
 U: Play Man Like Me by heather b.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "man like me" && contains~(artists, "heather b.") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "man like me" && contains(artists, null^^com.spotify:artist("heather b.")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2074
+# snips-nlu/spotify-2074
 U: please, a sound track of Jyotsna Radhakrishnan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "jyotsna radhakrishnan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("jyotsna radhakrishnan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2075
-U: Play some Darkcore.
+# snips-nlu/spotify-2075
+U: Play some Darkcore .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "darkcore") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "darkcore") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2076
+# snips-nlu/spotify-2076
 U: i want to listen to Say It Again by Blackstratblues
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Blackstratblues" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "say it again" && contains(artists, null^^com.spotify:artist("blackstratblues")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2079
+# snips-nlu/spotify-2079
 U: I want to hear music from the top fifty by Yasuhiko Fukuda
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "yasuhiko fukuda") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("yasuhiko fukuda")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2082
+# snips-nlu/spotify-2082
 U: I'd like to listen to mark rae
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "mark rae" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "mark rae")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2085
+# snips-nlu/spotify-2085
 U: I wanna listen to Electroclash
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "electroclash") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "electroclash") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2089
+# snips-nlu/spotify-2089
 U: Play the Vic Damone album named Tuonela
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "vic damone") && id =~ "tuonela" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), contains(artists, null^^com.spotify:artist("vic damone")) && id =~ "tuonela")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2096
+# snips-nlu/spotify-2096
 U: Can you play the Star Tales album by Colleen?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "star tales" && contains~(artists, "colleen") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "star tales" && contains(artists, null^^com.spotify:artist("colleen")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2097
+# snips-nlu/spotify-2097
 U: Play some G. V. Prakash Kumar
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "G. V. Prakash Kumar" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "G. V. Prakash Kumar")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2107
+# snips-nlu/spotify-2107
 U: can i lesten to the latest album of T-bone Burnett
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains~(artists, "t-bone burnett") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("t-bone burnett")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2109
-U: Play some good music from Jamelia.
+# snips-nlu/spotify-2109
+U: Play some good music from Jamelia .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "jamelia") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jamelia")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2110
-U: Play Alabama Concerto by Kou Shibasaki.
+# snips-nlu/spotify-2110
+U: Play Alabama Concerto by Kou Shibasaki .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "alabama concerto" && contains~(artists, "kou shibasaki") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "alabama concerto" && contains(artists, null^^com.spotify:artist("kou shibasaki")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2114
-U: Let's listen to the best from Jeff Loomis.
+# snips-nlu/spotify-2114
+U: Let's listen to the best from Jeff Loomis .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "jeff loomis") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("jeff loomis")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2119
+# snips-nlu/spotify-2119
 U: I want to hear Nellie Mckay's new music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "nellie mckay") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("nellie mckay")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2120
+# snips-nlu/spotify-2120
 U: Play Moris Tepper
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Moris Tepper" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Moris Tepper")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2124
-U: Play Maria Severa Onofriana and sort by most popular.
+# snips-nlu/spotify-2124
+U: Play Maria Severa Onofriana and sort by most popular .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "maria severa onofriana") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("maria severa onofriana")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2127
-U: Play Too Much Rain by the artist D-loc.
+# snips-nlu/spotify-2127
+U: Play Too Much Rain by the artist D-loc .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "D-loc" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "too much rain" && contains(artists, null^^com.spotify:artist("d-loc")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2128
+# snips-nlu/spotify-2128
 U: Play something by Louisiana Blues
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "louisiana blues") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "louisiana blues") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2129
+# snips-nlu/spotify-2129
 U: play This Is Colour by Panda Bear
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Panda Bear" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "this is colour" && contains(artists, null^^com.spotify:artist("panda bear")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2132
+# snips-nlu/spotify-2132
 U: Play rock like war from Mohammad Reza Lotfi please
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Mohammad Reza Lotfi" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "rock like war" && contains(artists, null^^com.spotify:artist("mohammad reza lotfi")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2135
+# snips-nlu/spotify-2135
 U: Play Ashita E by Ian Anderson
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ian Anderson" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "ashita e" && contains(artists, null^^com.spotify:artist("ian anderson")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2139
-U: Play the top-5 track from Boris Liatochinski.
+# snips-nlu/spotify-2139
+U: Play the top-5 track from Boris Liatochinski .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "boris liatochinski") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("boris liatochinski")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2145
+# snips-nlu/spotify-2145
 U: Play some fun-punk
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "fun-punk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "fun-punk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2148
+# snips-nlu/spotify-2148
 U: Play Tom Thacker through a top sort.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "tom thacker") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("tom thacker")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2150
+# snips-nlu/spotify-2150
 U: I want to hear from Pepe Marchena song Delaware
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "pepe marchena") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("pepe marchena")) && id =~ "delaware")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2155
+# snips-nlu/spotify-2151
+U: Play Monts Et Merveilles .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "monts et merveilles")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-2155
 U: Play some Jerry Dixon
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Jerry Dixon" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Jerry Dixon")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2157
-U: Please play the genre Rock Strumentale.
+# snips-nlu/spotify-2157
+U: Please play the genre Rock Strumentale .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "rock strumentale") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "rock strumentale") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2161
+# snips-nlu/spotify-2161
 U: Play some pop music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "pop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "pop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2162
-U: Play the greatest hits by Inoj.
+# snips-nlu/spotify-2162
+U: Play the greatest hits by Inoj .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "inoj") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("inoj")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2167
-U: I wish to listen to Gonna Get Along Without Ya Now by Ian Curtis.
+# snips-nlu/spotify-2167
+U: I wish to listen to Gonna Get Along Without Ya Now by Ian Curtis .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ian Curtis" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "gonna get along without ya now" && contains(artists, null^^com.spotify:artist("ian curtis")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2170
-U: Please play With Echoes In The Movement Of Stone by Faith Evans.
+# snips-nlu/spotify-2170
+U: Please play With Echoes In The Movement Of Stone by Faith Evans .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "with echoes in the movement of stone" && contains~(artists, "faith evans") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "with echoes in the movement of stone" && contains(artists, null^^com.spotify:artist("faith evans")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2173
+# snips-nlu/spotify-2173
 U: Play Gary Jules's latest music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "gary jules") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("gary jules")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2174
+# snips-nlu/spotify-2174
 U: Let's hear something from Elena Risteska
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Elena Risteska" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Elena Risteska")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2177
+# snips-nlu/spotify-2177
 U: Could you play the album B Men Gahō by Nathaniel Shilkret
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "b men gahō" && contains~(artists, "nathaniel shilkret") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "b men gahō" && contains(artists, null^^com.spotify:artist("nathaniel shilkret")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2178
+# snips-nlu/spotify-2178
 U: I want to hear music from the Lotus Flower album by Andy Mccoy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "lotus flower" && contains~(artists, "andy mccoy") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "lotus flower" && contains(artists, null^^com.spotify:artist("andy mccoy")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2179
-U: Please play Different Slanguages by Fred Labour.
+# snips-nlu/spotify-2179
+U: Please play Different Slanguages by Fred Labour .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "different slanguages" && contains~(artists, "fred labour") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "different slanguages" && contains(artists, null^^com.spotify:artist("fred labour")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2181
+# snips-nlu/spotify-2181
 U: Play some pambiche please
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "pambiche") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "pambiche") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2191
+# snips-nlu/spotify-2183
+U: I want to listen to Foreign Affair .
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.song(), id =~ "foreign affair")[1] => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-2191
 U: play Facedown by Maximum Bob
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "facedown" && contains~(artists, "maximum bob") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "facedown" && contains(artists, null^^com.spotify:artist("maximum bob")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2193
+# snips-nlu/spotify-2193
 U: Play Bad Boy Bill
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Bad Boy Bill" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Bad Boy Bill")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2195
-U: Play the latest Bobby Darin.
+# snips-nlu/spotify-2195
+U: Play the latest Bobby Darin .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "bobby darin") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("bobby darin")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2197
+# snips-nlu/spotify-2197
 U: Play the track Fight On, State by Yuvan Shankar Raja
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "yuvan shankar raja") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "fight on, state" && contains(artists, null^^com.spotify:artist("yuvan shankar raja")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2203
-U: I want to hear the album Live In Munich by Laura Love.
+# snips-nlu/spotify-2203
+U: I want to hear the album Live In Munich by Laura Love .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "live in munich" && contains~(artists, "laura love") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "live in munich" && contains(artists, null^^com.spotify:artist("laura love")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2205
+# snips-nlu/spotify-2205
 U: Play the sound track from Raymond Murray Schafer please
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "raymond murray schafer") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("raymond murray schafer")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2210
+# snips-nlu/spotify-2210
 U: Play the man who sold the world from Steve Swell
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the man who sold the world" && contains~(artists, "steve swell") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the man who sold the world" && contains(artists, null^^com.spotify:artist("steve swell")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2211
+# snips-nlu/spotify-2211
 U: Play biguine music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "biguine") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "biguine") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2212
-U: Play the latest Peter Green.
+# snips-nlu/spotify-2212
+U: Play the latest Peter Green .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "peter green") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("peter green")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2214
+# snips-nlu/spotify-2214
 U: Play something from the genre muzyka pop
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "muzyka pop") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "muzyka pop") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2216
+# snips-nlu/spotify-2216
 U: I want to hear music from the genre Ecossaise
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "ecossaise") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "ecossaise") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2218
-U: I want to hear Aki Nawaz, play the song fair annie.
+# snips-nlu/spotify-2218
+U: I want to hear Aki Nawaz, play the song fair annie .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "aki nawaz") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("aki nawaz")) && id =~ "fair annie")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2221
+# snips-nlu/spotify-2221
 U: Please play below the lion rock by stereo mike
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "stereo mike" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "below the lion rock" && contains(artists, null^^com.spotify:artist("stereo mike")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2223
-U: Play the album entitled Se Potrei Avere Te.
+# snips-nlu/spotify-2223
+U: Play the album entitled Se Potrei Avere Te .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "se potrei avere te" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "se potrei avere te")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2224
+# snips-nlu/spotify-2224
 U: give me some Last Emperor
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Last Emperor" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Last Emperor")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2225
-U: Play some art punk.
+# snips-nlu/spotify-2225
+U: Play some art punk .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "art punk") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "art punk") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2228
+# snips-nlu/spotify-2228
 U: Play Donny Tourette's Push The Button
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Donny Tourette" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("donny tourette")) && id =~ "push the button")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2229
-U: I want to listen to an album from Sibel.
+# snips-nlu/spotify-2229
+U: I want to listen to an album from Sibel .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "sibel") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("sibel")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2231
-U: Play addicts: black meddle, part ii.
+# snips-nlu/spotify-2231
+U: Play addicts: black meddle, part ii .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "addicts: black meddle, part ii" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "addicts: black meddle, part ii")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2232
-U: Play the best music from Klaus Badelt.
+# snips-nlu/spotify-2232
+U: Play the best music from Klaus Badelt .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "klaus badelt") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("klaus badelt")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2236
+# snips-nlu/spotify-2235
+U: Play a Nóta song
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => @com.spotify.song(), contains~(genres, "nóta") => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-2236
 U: play on the good ship lollipop by Anthony Hamilton
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Anthony Hamilton" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "on the good ship lollipop" && contains(artists, null^^com.spotify:artist("anthony hamilton")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2245
+# snips-nlu/spotify-2245
 U: I want to hear the last album from Carsten Bohn
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), contains~(artists, "carsten bohn") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort release_date desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("carsten bohn")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2251
+# snips-nlu/spotify-2251
 U: play the last Niney The Observer song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "niney the observer") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("niney the observer")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2253
-U: Play One Way Ticket by Ray Kennedy.
+# snips-nlu/spotify-2253
+U: Play One Way Ticket by Ray Kennedy .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Ray Kennedy" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "one way ticket" && contains(artists, null^^com.spotify:artist("ray kennedy")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2258
+# snips-nlu/spotify-2258
 U: Please play the last track from abbath
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "abbath") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("abbath")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2261
+# snips-nlu/spotify-2261
 U: Play music by larry mullen jr.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "larry mullen jr." => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "larry mullen jr.")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2265
-U: Play some Rumba Africana.
+# snips-nlu/spotify-2265
+U: Play some Rumba Africana .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "rumba africana") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "rumba africana") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2268
+# snips-nlu/spotify-2268
 U: last song by Latifa
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "latifa") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("latifa")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2275
+# snips-nlu/spotify-2275
 U: I want to listen to the track Close To The Edge
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "close to the edge")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2276
+# snips-nlu/spotify-2276
 U: I want to listen to some Aaliyah
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Aaliyah" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Aaliyah")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2277
-U: I want to listen to Merrily We Roll Along by Marko Desantis.
+# snips-nlu/spotify-2277
+U: I want to listen to Merrily We Roll Along by Marko Desantis .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Marko Desantis" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "merrily we roll along" && contains(artists, null^^com.spotify:artist("marko desantis")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2278
+# snips-nlu/spotify-2278
 U: Play the newest Roger Troutman track possible
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "roger troutman") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("roger troutman")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2279
+# snips-nlu/spotify-2279
 U: Play some P. J. Proby
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "P. J. Proby" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "P. J. Proby")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2280
-U: Play some diva house.
+# snips-nlu/spotify-2280
+U: Play some diva house .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "diva house") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "diva house") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2281
+# snips-nlu/spotify-2281
 U: I want to hear the album Picchio Dal Pozzo from Con Hunley
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "picchio dal pozzo" && contains~(artists, "con hunley") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "picchio dal pozzo" && contains(artists, null^^com.spotify:artist("con hunley")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2282
+# snips-nlu/spotify-2282
 U: play almost independence day by Vitas
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Vitas" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "almost independence day" && contains(artists, null^^com.spotify:artist("vitas")))[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2283
+# snips-nlu/spotify-2283
 U: Play the song from the genre Sunshine Reggae that appeals to me.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), contains~(genres, "sunshine reggae") => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => @com.spotify.song(), contains~(genres, "sunshine reggae") => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2286
+# snips-nlu/spotify-2286
 U: Play the track Coma
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song() => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => (@com.spotify.song(), id =~ "coma")[1] => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2287
+# snips-nlu/spotify-2287
 U: I wish to listen to Roni Duani 's music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Roni Duani" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.artist(), id =~ "Roni Duani")[1] => @com.spotify.play_artist(artist=id);
 ====
-# nlu/spotify-2292
-U: Play a sound track from Gregory Douglass.
+# snips-nlu/spotify-2292
+U: Play a sound track from Gregory Douglass .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "gregory douglass") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("gregory douglass")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2295
-U: Plaly The Ladybug Transistor by Loreena Mckennitt.
+# snips-nlu/spotify-2295
+U: Plaly The Ladybug Transistor by Loreena Mckennitt .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "the ladybug transistor" && contains~(artists, "loreena mckennitt") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "the ladybug transistor" && contains(artists, null^^com.spotify:artist("loreena mckennitt")))[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2296
-U: Play the latest music from Mark Knopfler.
+# snips-nlu/spotify-2296
+U: Play the latest music from Mark Knopfler .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "mark knopfler") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("mark knopfler")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2298
+# snips-nlu/spotify-2298
 U: Play Tyrants And Wraiths
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), id =~ "tyrants and wraiths" => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => (@com.spotify.album(), id =~ "tyrants and wraiths")[1] => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2299
+# snips-nlu/spotify-2299
 U: Play Before I Grew Up To Love You by Wafah Dufour
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.artist(), id =~ "Wafah Dufour" => notify;
-UT: now => @com.spotify.play_artist(artist=$?);
+UT: now => (@com.spotify.song(), id =~ "before i grew up to love you" && contains(artists, null^^com.spotify:artist("wafah dufour")))[1] => @com.spotify.play_song(song=id);
+

--- a/main/com.spotify/eval/dev/nlu-benchmark/convert_to_dialogue.py
+++ b/main/com.spotify/eval/dev/nlu-benchmark/convert_to_dialogue.py
@@ -30,7 +30,10 @@ def construct_thingtalk(entities, sortObj):
         "sound track": "song",
         "album": "album",
     }
+
     if len(sortObj.keys()) > 0:
+        if "release_date" in sortObj.keys():
+            hasID = True
         sort_query = (
             "sort " + list(sortObj.keys())[0] + " " + list(sortObj.values())[0] + " of "
         )
@@ -99,9 +102,12 @@ def construct_thingtalk(entities, sortObj):
             return None
     query_type = query_type or "song"
 
-    query = "%s@com.spotify.%s()" % (sort_query, query_type)
+    query = "@com.spotify.%s()" % (query_type)
     if len(filters) > 0:
         query += (", " + "&& ".join(filters)).strip()
+
+    if sort_query:
+        query = "%s(%s)" % (sort_query, query)
 
     if hasID:
         query = "UT: now => (" + query + ")[1]"

--- a/main/com.spotify/eval/dev/nlu-benchmark/convert_to_dialogue.py
+++ b/main/com.spotify/eval/dev/nlu-benchmark/convert_to_dialogue.py
@@ -1,7 +1,7 @@
 import json
 from fuzzywuzzy import fuzz
 
-entityTypes = ["artist", "album", "year", "genre", "sort", "music_item"]
+entityTypes = ["track", "artist", "album", "year", "genre", "sort", "music_item"]
 sortTypes = {
     "popular": {"popularity": "desc"},
     "new": {"release_date": "desc"},
@@ -21,6 +21,7 @@ def match_ratio(str1, str2):
 def construct_thingtalk(entities, sortObj):
     query_type = ""
     sort_query = ""
+    hasID = False
     filters = []
     musicItems = {
         "song": "song",
@@ -36,13 +37,16 @@ def construct_thingtalk(entities, sortObj):
 
     for entity in entities:
         if entity["entity"] == "genre":
-            query_type = "artist"
             filters.append("""contains~(genres, "%s") """ % entity["text"].lower())
         elif entity["entity"] == "artist":
             if len(entities) > 1:
-                filters.append("""contains~(artists, "%s") """ % entity["text"].lower())
+                filters.append(
+                    """contains(artists, null^^com.spotify:artist("%s")) """
+                    % (entity["text"].lower())
+                )
             else:
                 query_type = "artist"
+                hasID = True
                 filters.append("""id =~ "%s" """ % entity["text"])
         elif entity["entity"] == "year":
             lower_year = entity["text"]
@@ -83,9 +87,11 @@ def construct_thingtalk(entities, sortObj):
                 return None
         elif entity["entity"] == "track":
             query_type = "song"
+            hasID = True
             filters.append("""id =~ "%s" """ % entity["text"].lower())
         elif entity["entity"] == "album":
             query_type = "album"
+            hasID = True
             filters.append("""id =~ "%s" """ % entity["text"].lower())
         elif entity["entity"] == "sort":
             continue
@@ -93,20 +99,25 @@ def construct_thingtalk(entities, sortObj):
             return None
     query_type = query_type or "song"
 
-    query = "UT: now => %s@com.spotify.%s()" % (sort_query, query_type)
+    query = "%s@com.spotify.%s()" % (sort_query, query_type)
     if len(filters) > 0:
-        query += ", %s=> notify;\n" % (("&& ").join(filters))
-    else:
-        query += " => notify;\n"
-    query += "UT: now => @com.spotify.play_%s(%s=$?);" % (query_type, query_type)
+        query += (", " + "&& ".join(filters)).strip()
 
+    if hasID:
+        query = "UT: now => (" + query + ")[1]"
+    else:
+        query = "UT: now => " + query
+
+    query += " => @com.spotify.play_%s(%s=id);\n" % (query_type, query_type)
     return query
 
 
 with open("train_PlayMusic_full.json", "rb") as json_file, open(
     "train_PlayMusic.json", "rb"
 ) as json_file2:
-    with open("annotated.txt", "w") as text_file:
+    with open("annotated.txt", "w") as annotated_txt, open(
+        "dropped.txt", "w"
+    ) as dropped_txt:
         music_data = json.load(json_file)
         music_data2 = json.load(json_file2)
         data = music_data["PlayMusic"] + music_data2["PlayMusic"]
@@ -115,7 +126,10 @@ with open("train_PlayMusic_full.json", "rb") as json_file, open(
             entry = data[i]["data"]
             input_sentence = ""
             for text in entry:
-                input_sentence += text["text"]
+                if text["text"] == ".":
+                    input_sentence += " ."
+                else:
+                    input_sentence += text["text"]
             entities = [entity for entity in entry if "entity" in entity.keys()]
             for entity in entities:
                 if entity["entity"] == "service":
@@ -141,9 +155,19 @@ with open("train_PlayMusic_full.json", "rb") as json_file, open(
             if len(entities) > 0:
                 query = construct_thingtalk(entities, sortObj)
                 if query:
-                    text_file.write("# nlu/spotify-" + str(i) + "\n")
-                    text_file.write("U: " + input_sentence + "\n")
-                    text_file.write(
-                        "UT: $dialogue @org.thingpedia.dialogue.transaction.execute;\n"
-                    )
-                    text_file.write(query + "\n====\n")
+                    if "makeDate" in query:
+                        dropped_txt.write("====\n")
+                        dropped_txt.write("# snips-nlu/spotify-" + str(i) + "\n")
+                        dropped_txt.write("U: " + input_sentence + "\n")
+                        dropped_txt.write(
+                            "UT: $dialogue @org.thingpedia.dialogue.transaction.execute;\n"
+                        )
+                        dropped_txt.write(query)
+                    else:
+                        annotated_txt.write("====\n")
+                        annotated_txt.write("# snips-nlu/spotify-" + str(i) + "\n")
+                        annotated_txt.write("U: " + input_sentence + "\n")
+                        annotated_txt.write(
+                            "UT: $dialogue @org.thingpedia.dialogue.transaction.execute;\n"
+                        )
+                        annotated_txt.write(query)

--- a/main/com.spotify/eval/dev/temporarily-removed.txt
+++ b/main/com.spotify/eval/dev/temporarily-removed.txt
@@ -468,7 +468,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("blow
 # snips-nlu/spotify-8
 U: play a tune by Syreeta Wright from twenties from the top
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("syreeta wright")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("syreeta wright")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-13
 U: Play some sixties music.
@@ -528,7 +528,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_
 # snips-nlu/spotify-112
 U: Play a top fifty track from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-117
 U: play something from 1981
@@ -678,7 +678,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1995, 1, 1) && release_
 # snips-nlu/spotify-317
 U: play a top 50  tune from the twenties by Willi Williams
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("willi williams")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("willi williams"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-318
 U: play fifties track music
@@ -778,7 +778,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("greg
 # snips-nlu/spotify-444
 U: Play that new song from 1970
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-449
 U: I want to hear some of David Gilmour's music from 1973
@@ -793,12 +793,12 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_
 # snips-nlu/spotify-489
 U: Play the best songs of 2016
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-493
 U: Play an album from the fourties, new first.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31)))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-504
 U: Play fifties music
@@ -863,12 +863,12 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_
 # snips-nlu/spotify-590
 U: Play some good music from 2012 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2012, 1, 1) && release_date <= makeDate(2012, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(2012, 1, 1) && release_date <= makeDate(2012, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-592
 U: Play the top hits of 2016
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-598
 U: play a track from the thirties
@@ -893,12 +893,12 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_
 # snips-nlu/spotify-646
 U: Will you play me the most popular sound track from 2006
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-648
 U: Play new track from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-656
 U: Play some fifties music by Origa .
@@ -913,7 +913,7 @@ UT: now => @com.spotify.album(), release_date >= makeDate(2016, 1, 1) && release
 # snips-nlu/spotify-685
 U: Play the top 1991 sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-688
 U: Play a sixties song by Classified
@@ -923,7 +923,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_
 # snips-nlu/spotify-693
 U: Play top-ten eighties song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-696
 U: play dj kentaro from the year 1994
@@ -943,7 +943,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_
 # snips-nlu/spotify-702
 U: Play the newest released song from 1951
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1951, 1, 1) && release_date <= makeDate(1951, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1951, 1, 1) && release_date <= makeDate(1951, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-708
 U: play anything from the twenties
@@ -963,7 +963,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(2005, 1, 1) && release_
 # snips-nlu/spotify-722
 U: Play the best 1981 sound track from Ric Fierabracci
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) && contains(artists, null^^com.spotify:artist("ric fierabracci")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) && contains(artists, null^^com.spotify:artist("ric fierabracci"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-729
 U: Play fifties from Sirusho Harutyunyan
@@ -983,7 +983,7 @@ UT: now => @com.spotify.album(), release_date >= makeDate(1920, 1, 1) && release
 # snips-nlu/spotify-764
 U: I want to hear a good song from 2016
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-772
 U: Play a Wendy Carlos song from 2002
@@ -993,7 +993,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("wend
 # snips-nlu/spotify-773
 U: Play a new song form the eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-779
 U: Play sound track  music from the twenties
@@ -1003,7 +1003,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_
 # snips-nlu/spotify-782
 U: I'd like to listen to Diana Vickers best tune from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("diana vickers")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("diana vickers")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-789
 U: Play an album from the fourties
@@ -1158,7 +1158,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sun 
 # snips-nlu/spotify-1010
 U: I want to hear the latest twenties album from Kyle Riabko
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("kyle riabko")) => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("kyle riabko"))))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1017
 U: Can you play some eighties music
@@ -1183,7 +1183,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(2010, 1, 1) && release_
 # snips-nlu/spotify-1047
 U: Play the greatest 1966 album out there
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31)) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1049
 U: Play 1958 music
@@ -1244,7 +1244,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("nokk
 # snips-nlu/spotify-1124
 U: Play the latest 1973 album by Peter Derose .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) && contains(artists, null^^com.spotify:artist("peter derose")) => @com.spotify.play_album(album=id);
+UT: now => (sort release_date desc of (@com.spotify.album(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) && contains(artists, null^^com.spotify:artist("peter derose"))))[1] => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1125
 U: Play some Sabah from the eighties
@@ -1309,7 +1309,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1977, 1, 1) && release_
 # snips-nlu/spotify-1224
 U: play the album by Paul Barker playing the greatest from 1978
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("paul barker")) && release_date >= makeDate(1978, 1, 1) && release_date <= makeDate(1978, 12, 31) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), contains(artists, null^^com.spotify:artist("paul barker")) && release_date >= makeDate(1978, 1, 1) && release_date <= makeDate(1978, 12, 31)) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1230
 U: Play Henrie Mutuku album from 1957
@@ -1329,7 +1329,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_
 # snips-nlu/spotify-1249
 U: play top-twenty song from 2015
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1256
 U: Play music from Clark Kent in the year 1987
@@ -1354,17 +1354,17 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mark
 # snips-nlu/spotify-1274
 U: play the greatest 1972 album by Wes Dakus
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) && contains(artists, null^^com.spotify:artist("wes dakus")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) && contains(artists, null^^com.spotify:artist("wes dakus"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1281
 U: Play me the greatest track of 1966
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1307
 U: Play the last sound track by Soko from around 1975
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("soko")) && release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("soko")) && release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1311
 U: Play a song from 1973 .
@@ -1374,7 +1374,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_
 # snips-nlu/spotify-1314
 U: Play a new song from 1976 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1321
 U: Play me a song from 2016
@@ -1389,7 +1389,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1975, 1, 1) && release_
 # snips-nlu/spotify-1329
 U: play a top-fifty 1965 album by Ski
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) && contains(artists, null^^com.spotify:artist("ski")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) && contains(artists, null^^com.spotify:artist("ski"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1330
 U: Play  music from the thirties .
@@ -1399,7 +1399,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_
 # snips-nlu/spotify-1332
 U: Ply best 1973 sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1334
 U: I would like to hear music from 1993
@@ -1419,7 +1419,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_
 # snips-nlu/spotify-1358
 U: Play the most popular sound track from the 2006
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1362
 U: Play nineties
@@ -1469,7 +1469,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1971, 1, 1) && release_
 # snips-nlu/spotify-1429
 U: play 1977 good track tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1977, 1, 1) && release_date <= makeDate(1977, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1977, 1, 1) && release_date <= makeDate(1977, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1445
 U: Play any song from 2006
@@ -1514,7 +1514,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("barr
 # snips-nlu/spotify-1514
 U: play the best album from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31)) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1515
 U: Play music from 2016 .
@@ -1569,7 +1569,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("armi
 # snips-nlu/spotify-1611
 U: play a popular sort of fifties tune music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1613
 U: Play music from 1989 by Maya .
@@ -1639,7 +1639,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_
 # snips-nlu/spotify-1709
 U: Play some seventies track from top Rie Tomosaka
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains(artists, null^^com.spotify:artist("rie tomosaka")) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains(artists, null^^com.spotify:artist("rie tomosaka"))) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1714
 U: Please play a song for me from 1959
@@ -1684,7 +1684,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_
 # snips-nlu/spotify-1773
 U: Play a top-50 tune from 1982 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1982, 1, 1) && release_date <= makeDate(1982, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1982, 1, 1) && release_date <= makeDate(1982, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1777
 U: play the music track of 1998
@@ -1699,7 +1699,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("jody
 # snips-nlu/spotify-1787
 U: I'm looking for the last track by Fei Yu Ching from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fei yu ching")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("fei yu ching")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1793
 U: Play a song from 1950
@@ -1709,7 +1709,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_
 # snips-nlu/spotify-1795
 U: play a new song from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1803
 U: Play some ivy anderson from around 1967
@@ -1719,7 +1719,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("ivy 
 # snips-nlu/spotify-1804
 U: play the newest sound track from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1808
 U: play some sad songs from the fifties
@@ -1774,7 +1774,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_
 # snips-nlu/spotify-1869
 U: Play best fourties from david izquierdo on album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains(artists, null^^com.spotify:artist("david izquierdo")) => @com.spotify.play_album(album=id);
+UT: now => sort popularity desc of (@com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains(artists, null^^com.spotify:artist("david izquierdo"))) => @com.spotify.play_album(album=id);
 ====
 # snips-nlu/spotify-1885
 U: Play music from 2015
@@ -1789,7 +1789,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("caro
 # snips-nlu/spotify-1890
 U: Please play me a popular track from 1984 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1984, 1, 1) && release_date <= makeDate(1984, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => sort popularity desc of (@com.spotify.song(), release_date >= makeDate(1984, 1, 1) && release_date <= makeDate(1984, 12, 31)) => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1905
 U: Can you play some music from 1999
@@ -1834,7 +1834,7 @@ UT: now => @com.spotify.song(), release_date >= makeDate(1999, 1, 1) && release_
 # snips-nlu/spotify-1963
 U: play the last song from the thirties by Airto Moreira
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains(artists, null^^com.spotify:artist("airto moreira")) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains(artists, null^^com.spotify:artist("airto moreira"))))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-1968
 U: play Luis Alfonzo Larrain from 1995
@@ -1994,7 +1994,7 @@ UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("arif
 # snips-nlu/spotify-2168
 U: I'm looking for the last track by Fei Yu Ching from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fei yu ching")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
+UT: now => (sort release_date desc of (@com.spotify.song(), contains(artists, null^^com.spotify:artist("fei yu ching")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31)))[1] => @com.spotify.play_song(song=id);
 ====
 # snips-nlu/spotify-2171
 U: Play me a track from the sixties

--- a/main/com.spotify/eval/dev/temporarily-removed.txt
+++ b/main/com.spotify/eval/dev/temporarily-removed.txt
@@ -455,1965 +455,1648 @@ U: yes , have a good day .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: now => @com.spotify.play_songs(toPlay=["spotify:track:0G21yYKMZoHa30cYVi1iA8"^^com.spotify:song("Welcome To The Jungle"), "spotify:track:7snQQk1zcKl8gZ92AnueZW"^^com.spotify:song("Sweet Child O' Mine"), "spotify:track:5zA8vzDGqPl2AzZkEYQGKh"^^com.spotify:song("Uptown Girl"), "spotify:track:4xh7W7tlNMIczFhupCPniY"^^com.spotify:song("Go Your Own Way - 2004 Remaster"), "spotify:track:0YEg2JfkMeJ1hTYqop4A5o"^^com.spotify:song("7 Rings"), "spotify:track:5QTxFnGygVM4jFQiBovmRo"^^com.spotify:song("(Don't Fear) The Reaper"), "spotify:track:7oK9VyNzrYvRFo7nQEYkWN"^^com.spotify:song("Mr. Brightside"), "spotify:track:2zYzyRzz6pRmhPzyfMEC8s"^^com.spotify:song("Highway to Hell"), "spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"), "spotify:track:2WfaOiMkCvy7F5fcp2zZ8L"^^com.spotify:song("Take on Me")]);
 ====
-# nlu/spotify-4
+# snips-nlu/spotify-4
 U: Play Magic Sam from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "magic sam") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("magic sam")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-6
+# snips-nlu/spotify-6
 U: Play music by blowfly from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "blowfly") && release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("blowfly")) && release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-8
+# snips-nlu/spotify-8
 U: play a tune by Syreeta Wright from twenties from the top
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "syreeta wright") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("syreeta wright")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-13
+# snips-nlu/spotify-13
 U: Play some sixties music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-19
+# snips-nlu/spotify-19
 U: Play me some music by Prince Alla from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "prince alla") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("prince alla")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-34
+# snips-nlu/spotify-34
 U: play laura love songs from 1959
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "laura love") && release_date >= makeDate(1959, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("laura love")) && release_date >= makeDate(1959, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-62
+# snips-nlu/spotify-62
 U: PLay some fourties music from Erin Harkes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains~(artists, "erin harkes") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains(artists, null^^com.spotify:artist("erin harkes")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-71
+# snips-nlu/spotify-71
 U: Play music from 2002
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-78
+# snips-nlu/spotify-78
 U: Play me a song from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-86
+# snips-nlu/spotify-86
 U: I want to hear Papa Mali's songs from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "papa mali") && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("papa mali")) && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-92
+# snips-nlu/spotify-91
+U: I want to hear Ready by Frankenstein Drag Queens From Planet 13
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => (@com.spotify.album(), id =~ "ready" && contains(artists, null^^com.spotify:artist("frankenstein drag queens from planet 13")))[1] => @com.spotify.play_album(album=id);
+====
+# snips-nlu/spotify-92
 U: Play a song from the seventies by Pepe Aguilar
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains~(artists, "pepe aguilar") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains(artists, null^^com.spotify:artist("pepe aguilar")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-96
+# snips-nlu/spotify-96
 U: play songs from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-110
+# snips-nlu/spotify-110
 U: play a 1994 tune by Lena Horne
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) && contains~(artists, "lena horne") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) && contains(artists, null^^com.spotify:artist("lena horne")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-112
+# snips-nlu/spotify-112
 U: Play a top fifty track from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-117
+# snips-nlu/spotify-117
 U: play something from 1981
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-122
+# snips-nlu/spotify-122
 U: Play some songs from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-138
+# snips-nlu/spotify-138
 U: Play Niko from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "niko") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("niko")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-141
+# snips-nlu/spotify-141
 U: play some nineties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-144
+# snips-nlu/spotify-144
 U: Play music from 2015
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-145
+# snips-nlu/spotify-145
 U: Play music from 1964
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-152
+# snips-nlu/spotify-152
 U: Play me a nineties song by Joseph Genaro
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "joseph genaro") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("joseph genaro")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-156
+# snips-nlu/spotify-156
 U: Play some Rockwell from around 1996
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "rockwell") && release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("rockwell")) && release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-158
+# snips-nlu/spotify-158
 U: play something from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-160
+# snips-nlu/spotify-160
 U: play some 1991 Dave Barker
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) && contains~(artists, "dave barker") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) && contains(artists, null^^com.spotify:artist("dave barker")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-168
+# snips-nlu/spotify-168
 U: Play any song from 2001
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2001, 1, 1) && release_date <= makeDate(2001, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2001, 1, 1) && release_date <= makeDate(2001, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-175
+# snips-nlu/spotify-175
 U: play music from 1981
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-183
-U: Play Barbra Streisand music from 1997.
+# snips-nlu/spotify-183
+U: Play Barbra Streisand music from 1997 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "barbra streisand") && release_date >= makeDate(1997, 1, 1) && release_date <= makeDate(1997, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("barbra streisand")) && release_date >= makeDate(1997, 1, 1) && release_date <= makeDate(1997, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-193
+# snips-nlu/spotify-193
 U: Play music from the seventies for me. 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-198
-U: Play music from 2007.
+# snips-nlu/spotify-198
+U: Play music from 2007 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-199
+# snips-nlu/spotify-199
 U: Play me a song from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-209
+# snips-nlu/spotify-209
 U: Play eighties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-219
+# snips-nlu/spotify-219
 U: play music from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-220
+# snips-nlu/spotify-220
 U: I want to hear Somi's songs from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "somi") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("somi")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-221
+# snips-nlu/spotify-221
 U: play Tom Jones album from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "tom jones") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("tom jones")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-235
+# snips-nlu/spotify-235
 U: play 1970 trunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-237
-U: Play a track from 1985.
+# snips-nlu/spotify-237
+U: Play a track from 1985 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1985, 1, 1) && release_date <= makeDate(1985, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1985, 1, 1) && release_date <= makeDate(1985, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-270
-U: Play Trace Adkins' music from the thirties.
+# snips-nlu/spotify-270
+U: Play Trace Adkins' music from the thirties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "trace adkins") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("trace adkins")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-280
+# snips-nlu/spotify-280
 U: play Abhijeet Bhattacharya from 1986
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "abhijeet bhattacharya") && release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("abhijeet bhattacharya")) && release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-284
+# snips-nlu/spotify-284
 U: Play Dj Drama from the 1976
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "dj drama") && release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("dj drama")) && release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-288
-U: Play some music from the fourties.
+# snips-nlu/spotify-288
+U: Play some music from the fourties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-292
+# snips-nlu/spotify-292
 U: play fourties tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-300
+# snips-nlu/spotify-300
 U: Play eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-304
+# snips-nlu/spotify-304
 U: Play some music from 1995
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1995, 1, 1) && release_date <= makeDate(1995, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1995, 1, 1) && release_date <= makeDate(1995, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-317
+# snips-nlu/spotify-317
 U: play a top 50  tune from the twenties by Willi Williams
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains~(artists, "willi williams") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("willi williams")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-318
+# snips-nlu/spotify-318
 U: play fifties track music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-324
+# snips-nlu/spotify-324
 U: Play Hasan Saltik from 2004
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "hasan saltik") && release_date >= makeDate(2004, 1, 1) && release_date <= makeDate(2004, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("hasan saltik")) && release_date >= makeDate(2004, 1, 1) && release_date <= makeDate(2004, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-327
+# snips-nlu/spotify-327
 U: play wendy james from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "wendy james") && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("wendy james")) && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-333
+# snips-nlu/spotify-333
 U: Play me a song from 1976 by Bennie Moten
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31) && contains~(artists, "bennie moten") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31) && contains(artists, null^^com.spotify:artist("bennie moten")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-344
+# snips-nlu/spotify-344
 U: play Richard Thompson from the thirties song book
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "richard thompson") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("richard thompson")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-348
-U: Play a sixties song.
+# snips-nlu/spotify-348
+U: Play a sixties song .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-357
+# snips-nlu/spotify-357
 U: Lets hear some 2009 music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2009, 1, 1) && release_date <= makeDate(2009, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2009, 1, 1) && release_date <= makeDate(2009, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-363
+# snips-nlu/spotify-363
 U: Play some eighties music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-367
-U: Play some music from the thirties.
+# snips-nlu/spotify-367
+U: Play some music from the thirties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-371
-U: Play a track from 1959.
+# snips-nlu/spotify-371
+U: Play a track from 1959 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1959, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1959, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-387
+# snips-nlu/spotify-387
 U: Play me a song from the twenties by Randy Bachman
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains~(artists, "randy bachman") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("randy bachman")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-399
-U: Play music from 2011.
+# snips-nlu/spotify-399
+U: Play music from 2011 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2011, 1, 1) && release_date <= makeDate(2011, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2011, 1, 1) && release_date <= makeDate(2011, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-402
+# snips-nlu/spotify-402
 U: play an eighties track 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-403
+# snips-nlu/spotify-403
 U: Can you play me some eighties music by Adele
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains~(artists, "adele") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains(artists, null^^com.spotify:artist("adele")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-420
+# snips-nlu/spotify-420
 U: Please play some music from 1996
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-424
+# snips-nlu/spotify-424
 U: play some Kyle Ward from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "kyle ward") && release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("kyle ward")) && release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-435
+# snips-nlu/spotify-435
 U: Play music from 2010 by Jason Donovan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2010, 1, 1) && release_date <= makeDate(2010, 12, 31) && contains~(artists, "jason donovan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2010, 1, 1) && release_date <= makeDate(2010, 12, 31) && contains(artists, null^^com.spotify:artist("jason donovan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-437
-U: Play Giovanni Battista Guadagnini's 1982 tracks.
+# snips-nlu/spotify-437
+U: Play Giovanni Battista Guadagnini's 1982 tracks .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "giovanni battista guadagnini") && release_date >= makeDate(1982, 1, 1) && release_date <= makeDate(1982, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("giovanni battista guadagnini")) && release_date >= makeDate(1982, 1, 1) && release_date <= makeDate(1982, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-439
+# snips-nlu/spotify-439
 U: Play Greg Raposo songs from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "greg raposo") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("greg raposo")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-444
+# snips-nlu/spotify-444
 U: Play that new song from 1970
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-449
+# snips-nlu/spotify-449
 U: I want to hear some of David Gilmour's music from 1973
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "david gilmour") && release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("david gilmour")) && release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-479
+# snips-nlu/spotify-479
 U: play some eighties by Amirbai Karnataki
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains~(artists, "amirbai karnataki") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains(artists, null^^com.spotify:artist("amirbai karnataki")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-489
+# snips-nlu/spotify-489
 U: Play the best songs of 2016
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-493
+# snips-nlu/spotify-493
 U: Play an album from the fourties, new first.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-504
+# snips-nlu/spotify-504
 U: Play fifties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-520
+# snips-nlu/spotify-520
 U: play Robert Stoddard from 1988
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "robert stoddard") && release_date >= makeDate(1988, 1, 1) && release_date <= makeDate(1988, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("robert stoddard")) && release_date >= makeDate(1988, 1, 1) && release_date <= makeDate(1988, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-527
-U: Play some music from the thirties.
+# snips-nlu/spotify-527
+U: Play some music from the thirties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-528
+# snips-nlu/spotify-528
 U: Play 2011 music 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2011, 1, 1) && release_date <= makeDate(2011, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2011, 1, 1) && release_date <= makeDate(2011, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-536
+# snips-nlu/spotify-536
 U: Play me a 2003 song by Charles Neidich
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) && contains~(artists, "charles neidich") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) && contains(artists, null^^com.spotify:artist("charles neidich")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-537
+# snips-nlu/spotify-537
 U: I want to hear some songs from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-552
-U: Play an album from 1987.
+# snips-nlu/spotify-552
+U: Play an album from 1987 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-553
+# snips-nlu/spotify-553
 U: Play music from 1960
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1960, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1960, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-562
+# snips-nlu/spotify-562
 U: play something from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-565
+# snips-nlu/spotify-565
 U: Play music from the year 1964
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-581
+# snips-nlu/spotify-581
 U: Play an Asha Bhosle song from around 1964
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "asha bhosle") && release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("asha bhosle")) && release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-582
-U: Play music from the twenties.
+# snips-nlu/spotify-582
+U: Play music from the twenties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-590
-U: Play some good music from 2012.
+# snips-nlu/spotify-590
+U: Play some good music from 2012 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2012, 1, 1) && release_date <= makeDate(2012, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2012, 1, 1) && release_date <= makeDate(2012, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-592
+# snips-nlu/spotify-592
 U: Play the top hits of 2016
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-598
+# snips-nlu/spotify-598
 U: play a track from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-612
+# snips-nlu/spotify-612
 U: play the 2014 album from la lupe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(2014, 1, 1) && release_date <= makeDate(2014, 12, 31) && contains~(artists, "la lupe") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(2014, 1, 1) && release_date <= makeDate(2014, 12, 31) && contains(artists, null^^com.spotify:artist("la lupe")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-637
+# snips-nlu/spotify-637
 U: Play me a nineties sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-640
+# snips-nlu/spotify-640
 U: play music from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-646
+# snips-nlu/spotify-646
 U: Will you play me the most popular sound track from 2006
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-648
+# snips-nlu/spotify-648
 U: Play new track from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-656
-U: Play some fifties music by Origa.
+# snips-nlu/spotify-656
+U: Play some fifties music by Origa .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "origa") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("origa")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-667
+# snips-nlu/spotify-667
 U: play Solange 2016 album 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-685
+# snips-nlu/spotify-685
 U: Play the top 1991 sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-688
+# snips-nlu/spotify-688
 U: Play a sixties song by Classified
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) && contains~(artists, "classified") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) && contains(artists, null^^com.spotify:artist("classified")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-693
+# snips-nlu/spotify-693
 U: Play top-ten eighties song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-696
+# snips-nlu/spotify-696
 U: play dj kentaro from the year 1994
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "dj kentaro") && release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("dj kentaro")) && release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-697
+# snips-nlu/spotify-697
 U: play a twenties song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-698
+# snips-nlu/spotify-698
 U: Can you play me a track from the nineties?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-702
+# snips-nlu/spotify-702
 U: Play the newest released song from 1951
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1951, 1, 1) && release_date <= makeDate(1951, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1951, 1, 1) && release_date <= makeDate(1951, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-708
+# snips-nlu/spotify-708
 U: play anything from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-718
+# snips-nlu/spotify-718
 U: play a tune from 1962
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1962, 1, 1) && release_date <= makeDate(1962, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1962, 1, 1) && release_date <= makeDate(1962, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-721
+# snips-nlu/spotify-721
 U: Play music from 2005 by Justin Broadrick
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2005, 1, 1) && release_date <= makeDate(2005, 12, 31) && contains~(artists, "justin broadrick") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2005, 1, 1) && release_date <= makeDate(2005, 12, 31) && contains(artists, null^^com.spotify:artist("justin broadrick")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-722
+# snips-nlu/spotify-722
 U: Play the best 1981 sound track from Ric Fierabracci
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) && contains~(artists, "ric fierabracci") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1981, 1, 1) && release_date <= makeDate(1981, 12, 31) && contains(artists, null^^com.spotify:artist("ric fierabracci")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-729
+# snips-nlu/spotify-729
 U: Play fifties from Sirusho Harutyunyan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "sirusho harutyunyan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("sirusho harutyunyan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-735
+# snips-nlu/spotify-735
 U: Play twenties from Ken Floyd
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains~(artists, "ken floyd") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("ken floyd")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-757
+# snips-nlu/spotify-757
 U: Play any album from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-764
+# snips-nlu/spotify-764
 U: I want to hear a good song from 2016
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-772
+# snips-nlu/spotify-772
 U: Play a Wendy Carlos song from 2002
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "wendy carlos") && release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("wendy carlos")) && release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-773
+# snips-nlu/spotify-773
 U: Play a new song form the eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-779
+# snips-nlu/spotify-779
 U: Play sound track  music from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-782
+# snips-nlu/spotify-782
 U: I'd like to listen to Diana Vickers best tune from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), contains~(artists, "diana vickers") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("diana vickers")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-789
+# snips-nlu/spotify-789
 U: Play an album from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-791
+# snips-nlu/spotify-791
 U: play soem nineties Charles Thompson
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "charles thompson") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("charles thompson")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-793
-U: Let's hear some tunes from the thirties.
+# snips-nlu/spotify-793
+U: Let's hear some tunes from the thirties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-817
+# snips-nlu/spotify-817
 U: Play me a twenties song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-825
+# snips-nlu/spotify-825
 U: Play me a fifties song by Chingy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "chingy") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("chingy")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-830
+# snips-nlu/spotify-830
 U: Give me an album from 1972 to listen to.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-838
+# snips-nlu/spotify-838
 U: Play some sister rosetta tharpe songs from the eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "sister rosetta tharpe") && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sister rosetta tharpe")) && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-840
-U: Play a twenties tune by Jodie Aysha.
+# snips-nlu/spotify-840
+U: Play a twenties tune by Jodie Aysha .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains~(artists, "jodie aysha") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("jodie aysha")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-844
+# snips-nlu/spotify-844
 U: Play music by Paulinho Da Viola from 1965
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "paulinho da viola") && release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("paulinho da viola")) && release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-851
+# snips-nlu/spotify-851
 U: Play Tina Cousins from 1956
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "tina cousins") && release_date >= makeDate(1956, 1, 1) && release_date <= makeDate(1956, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("tina cousins")) && release_date >= makeDate(1956, 1, 1) && release_date <= makeDate(1956, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-853
+# snips-nlu/spotify-853
 U: Play me songs from 1955
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1955, 1, 1) && release_date <= makeDate(1955, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1955, 1, 1) && release_date <= makeDate(1955, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-858
+# snips-nlu/spotify-858
 U: play music from 2014
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2014, 1, 1) && release_date <= makeDate(2014, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2014, 1, 1) && release_date <= makeDate(2014, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-866
+# snips-nlu/spotify-866
 U: I want to hear music from carman from the 1966 album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "carman") && release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("carman")) && release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-869
+# snips-nlu/spotify-869
 U: Play Vic Ruggiero music from 2007
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "vic ruggiero") && release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("vic ruggiero")) && release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-872
+# snips-nlu/spotify-872
 U: Play fifties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-873
+# snips-nlu/spotify-873
 U: Play some nineties Eliza Carthy
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "eliza carthy") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("eliza carthy")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-882
+# snips-nlu/spotify-882
 U: Play Igor Nikolayev music from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "igor nikolayev") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("igor nikolayev")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-887
+# snips-nlu/spotify-887
 U: Play fifties music by Ahmed Abdul Malik
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "ahmed abdul malik") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("ahmed abdul malik")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-916
-U: Play music from 1958.
+# snips-nlu/spotify-916
+U: Play music from 1958 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-926
-U: Play some 1987 Edie Brickell.
+# snips-nlu/spotify-926
+U: Play some 1987 Edie Brickell .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) && contains~(artists, "edie brickell") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) && contains(artists, null^^com.spotify:artist("edie brickell")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-933
+# snips-nlu/spotify-933
 U: play caitlin cary from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "caitlin cary") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("caitlin cary")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-942
+# snips-nlu/spotify-942
 U: play any sixties song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-954
-U: Play some Paulinho Da Viola from 1965.
+# snips-nlu/spotify-954
+U: Play some Paulinho Da Viola from 1965 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "paulinho da viola") && release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("paulinho da viola")) && release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-966
+# snips-nlu/spotify-966
 U: Play me a song from 2008
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2008, 1, 1) && release_date <= makeDate(2008, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2008, 1, 1) && release_date <= makeDate(2008, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-986
+# snips-nlu/spotify-986
 U: play Paula Campbell music from 1993
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "paula campbell") && release_date >= makeDate(1993, 1, 1) && release_date <= makeDate(1993, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("paula campbell")) && release_date >= makeDate(1993, 1, 1) && release_date <= makeDate(1993, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-988
-U: Play some fifties music by Chris Brown.
+# snips-nlu/spotify-988
+U: Play some fifties music by Chris Brown .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "chris brown") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("chris brown")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-995
+# snips-nlu/spotify-995
 U: Play a song from 2003
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-997
+# snips-nlu/spotify-997
 U: Can I hear tod ashley music from 1953?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "tod ashley") && release_date >= makeDate(1953, 1, 1) && release_date <= makeDate(1953, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("tod ashley")) && release_date >= makeDate(1953, 1, 1) && release_date <= makeDate(1953, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1001
+# snips-nlu/spotify-1001
 U: Please play an album from 1987
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1005
+# snips-nlu/spotify-1005
 U: Play me Sun Ra songs from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "sun ra") && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sun ra")) && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1010
+# snips-nlu/spotify-1010
 U: I want to hear the latest twenties album from Kyle Riabko
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains~(artists, "kyle riabko") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("kyle riabko")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1017
+# snips-nlu/spotify-1017
 U: Can you play some eighties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1021
+# snips-nlu/spotify-1021
 U: play some seventies Dj Colette
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains~(artists, "dj colette") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains(artists, null^^com.spotify:artist("dj colette")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1022
+# snips-nlu/spotify-1022
 U: play music from 1950
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1950, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1950, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1030
+# snips-nlu/spotify-1030
 U: I want to hear that tune from 2010
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2010, 1, 1) && release_date <= makeDate(2010, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2010, 1, 1) && release_date <= makeDate(2010, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1047
+# snips-nlu/spotify-1047
 U: Play the greatest 1966 album out there
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1049
+# snips-nlu/spotify-1049
 U: Play 1958 music
 
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1077
+# snips-nlu/spotify-1077
 U: I want to hear Steven Harwell from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "steven harwell") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("steven harwell")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1079
+# snips-nlu/spotify-1079
 U: Play 1958 by wayne petti
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) && contains~(artists, "wayne petti") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) && contains(artists, null^^com.spotify:artist("wayne petti")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1080
+# snips-nlu/spotify-1080
 U: Play something from 1985 by Billy Werner
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1985, 1, 1) && release_date <= makeDate(1985, 12, 31) && contains~(artists, "billy werner") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1985, 1, 1) && release_date <= makeDate(1985, 12, 31) && contains(artists, null^^com.spotify:artist("billy werner")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1088
+# snips-nlu/spotify-1088
 U: Play music from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1092
+# snips-nlu/spotify-1092
 U: Play me an eighties song by Wes Dakus
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains~(artists, "wes dakus") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains(artists, null^^com.spotify:artist("wes dakus")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1097
+# snips-nlu/spotify-1097
 U: I want to hear any tune from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1098
+# snips-nlu/spotify-1098
 U: Play Jono El Grande from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "jono el grande") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("jono el grande")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1104
-U: Play some music from the twenties.
+# snips-nlu/spotify-1104
+U: Play some music from the twenties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1108
+# snips-nlu/spotify-1108
 U: Play me a song from 1972 by Sweet Emma Barrett
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) && contains~(artists, "sweet emma barrett") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) && contains(artists, null^^com.spotify:artist("sweet emma barrett")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1117
+# snips-nlu/spotify-1117
 U: I want to hear Nokko's songs from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "nokko") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("nokko")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1124
-U: Play the latest 1973 album by Peter Derose.
+# snips-nlu/spotify-1124
+U: Play the latest 1973 album by Peter Derose .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) && contains~(artists, "peter derose") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort release_date desc of @com.spotify.album(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) && contains(artists, null^^com.spotify:artist("peter derose")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1125
+# snips-nlu/spotify-1125
 U: Play some Sabah from the eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "sabah") && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sabah")) && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1129
-U: Play a sound track from 1952.
+# snips-nlu/spotify-1129
+U: Play a sound track from 1952 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1952, 1, 1) && release_date <= makeDate(1952, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1952, 1, 1) && release_date <= makeDate(1952, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1138
+# snips-nlu/spotify-1138
 U: Play me a song by Avispa Music from 1965
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "avispa music") && release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("avispa music")) && release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1157
+# snips-nlu/spotify-1157
 U: play an eighties song by Ler Lalonde
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains~(artists, "ler lalonde") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains(artists, null^^com.spotify:artist("ler lalonde")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1164
+# snips-nlu/spotify-1164
 U: I want to hear some twenties music from Billy Sheehan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains~(artists, "billy sheehan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) && contains(artists, null^^com.spotify:artist("billy sheehan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1165
+# snips-nlu/spotify-1165
 U: Play some songs from 1958
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1180
+# snips-nlu/spotify-1180
 U: Can you play a sound track from 1963?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1963, 1, 1) && release_date <= makeDate(1963, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1963, 1, 1) && release_date <= makeDate(1963, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1196
+# snips-nlu/spotify-1196
 U: play a sixties song by George Sanger
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) && contains~(artists, "george sanger") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) && contains(artists, null^^com.spotify:artist("george sanger")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1200
+# snips-nlu/spotify-1200
 U: Play a song by Alasdair Roberts from 1996
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "alasdair roberts") && release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("alasdair roberts")) && release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1207
+# snips-nlu/spotify-1207
 U: Play Eddie Meduza from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "eddie meduza") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("eddie meduza")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1211
+# snips-nlu/spotify-1211
 U: play Vivian Stanshall from 1962
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "vivian stanshall") && release_date >= makeDate(1962, 1, 1) && release_date <= makeDate(1962, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("vivian stanshall")) && release_date >= makeDate(1962, 1, 1) && release_date <= makeDate(1962, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1213
+# snips-nlu/spotify-1213
 U: Play music from 1977
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1977, 1, 1) && release_date <= makeDate(1977, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1977, 1, 1) && release_date <= makeDate(1977, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1224
+# snips-nlu/spotify-1224
 U: play the album by Paul Barker playing the greatest from 1978
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), contains~(artists, "paul barker") && release_date >= makeDate(1978, 1, 1) && release_date <= makeDate(1978, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), contains(artists, null^^com.spotify:artist("paul barker")) && release_date >= makeDate(1978, 1, 1) && release_date <= makeDate(1978, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1230
+# snips-nlu/spotify-1230
 U: Play Henrie Mutuku album from 1957
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "henrie mutuku") && release_date >= makeDate(1957, 1, 1) && release_date <= makeDate(1957, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("henrie mutuku")) && release_date >= makeDate(1957, 1, 1) && release_date <= makeDate(1957, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1232
+# snips-nlu/spotify-1232
 U: play some 2002 music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1233
+# snips-nlu/spotify-1233
 U: I want to hear that track from 1991
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1249
+# snips-nlu/spotify-1249
 U: play top-twenty song from 2015
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1256
+# snips-nlu/spotify-1256
 U: Play music from Clark Kent in the year 1987
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "clark kent") && release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("clark kent")) && release_date >= makeDate(1987, 1, 1) && release_date <= makeDate(1987, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1261
+# snips-nlu/spotify-1261
 U: Play some music from 1985 by Rolf Harris
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1985, 1, 1) && release_date <= makeDate(1985, 12, 31) && contains~(artists, "rolf harris") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1985, 1, 1) && release_date <= makeDate(1985, 12, 31) && contains(artists, null^^com.spotify:artist("rolf harris")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1268
+# snips-nlu/spotify-1268
 U: play a track from 2004
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2004, 1, 1) && release_date <= makeDate(2004, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2004, 1, 1) && release_date <= makeDate(2004, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1273
-U: Play some Mark Tremonti from the thirties.
+# snips-nlu/spotify-1273
+U: Play some Mark Tremonti from the thirties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "mark tremonti") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mark tremonti")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1274
+# snips-nlu/spotify-1274
 U: play the greatest 1972 album by Wes Dakus
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) && contains~(artists, "wes dakus") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) && contains(artists, null^^com.spotify:artist("wes dakus")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1281
+# snips-nlu/spotify-1281
 U: Play me the greatest track of 1966
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1307
+# snips-nlu/spotify-1307
 U: Play the last sound track by Soko from around 1975
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "soko") && release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("soko")) && release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1311
-U: Play a song from 1973.
+# snips-nlu/spotify-1311
+U: Play a song from 1973 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1314
-U: Play a new song from 1976.
+# snips-nlu/spotify-1314
+U: Play a new song from 1976 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1976, 1, 1) && release_date <= makeDate(1976, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1321
+# snips-nlu/spotify-1321
 U: Play me a song from 2016
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1326
+# snips-nlu/spotify-1326
 U: I want to hear music from 1975
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1329
+# snips-nlu/spotify-1329
 U: play a top-fifty 1965 album by Ski
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) && contains~(artists, "ski") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1965, 1, 1) && release_date <= makeDate(1965, 12, 31) && contains(artists, null^^com.spotify:artist("ski")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1330
-U: Play  music from the thirties.
+# snips-nlu/spotify-1330
+U: Play  music from the thirties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1332
+# snips-nlu/spotify-1332
 U: Ply best 1973 sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1334
+# snips-nlu/spotify-1334
 U: I would like to hear music from 1993
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1993, 1, 1) && release_date <= makeDate(1993, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1993, 1, 1) && release_date <= makeDate(1993, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1337
+# snips-nlu/spotify-1337
 U: I want to hear Major Harris's songs from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "major harris") && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("major harris")) && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1350
+# snips-nlu/spotify-1350
 U: Can you play a song from the fourties by George Martin
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains~(artists, "george martin") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains(artists, null^^com.spotify:artist("george martin")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1358
+# snips-nlu/spotify-1358
 U: Play the most popular sound track from the 2006
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1362
+# snips-nlu/spotify-1362
 U: Play nineties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1379
+# snips-nlu/spotify-1379
 U: Play some music from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1384
-U: Play a song from 2013.
+# snips-nlu/spotify-1384
+U: Play a song from 2013 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2013, 1, 1) && release_date <= makeDate(2013, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2013, 1, 1) && release_date <= makeDate(2013, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1385
+# snips-nlu/spotify-1385
 U: play 1951 tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1951, 1, 1) && release_date <= makeDate(1951, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1951, 1, 1) && release_date <= makeDate(1951, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1387
+# snips-nlu/spotify-1387
 U: Play any nineties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1406
-U: Play some Oleg Anofriyev from 1960.
+# snips-nlu/spotify-1406
+U: Play some Oleg Anofriyev from 1960 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "oleg anofriyev") && release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1960, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("oleg anofriyev")) && release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1960, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1412
+# snips-nlu/spotify-1412
 U: Play some Antony Harding songs from the eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "antony harding") && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("antony harding")) && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1414
+# snips-nlu/spotify-1414
 U: Play music from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1425
+# snips-nlu/spotify-1425
 U: play something from 1971 by John Bonham
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1971, 1, 1) && release_date <= makeDate(1971, 12, 31) && contains~(artists, "john bonham") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1971, 1, 1) && release_date <= makeDate(1971, 12, 31) && contains(artists, null^^com.spotify:artist("john bonham")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1429
+# snips-nlu/spotify-1429
 U: play 1977 good track tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1977, 1, 1) && release_date <= makeDate(1977, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1977, 1, 1) && release_date <= makeDate(1977, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1445
+# snips-nlu/spotify-1445
 U: Play any song from 2006
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2006, 1, 1) && release_date <= makeDate(2006, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1446
+# snips-nlu/spotify-1446
 U: Play some Sonu Niigaam from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "sonu niigaam") && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sonu niigaam")) && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1459
+# snips-nlu/spotify-1459
 U: Play music from 1999
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1999, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1999, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1462
+# snips-nlu/spotify-1462
 U: I wish to listen to some fifties music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1486
+# snips-nlu/spotify-1486
 U: Play some music from 1962 from Adeyto
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1962, 1, 1) && release_date <= makeDate(1962, 12, 31) && contains~(artists, "adeyto") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1962, 1, 1) && release_date <= makeDate(1962, 12, 31) && contains(artists, null^^com.spotify:artist("adeyto")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1488
+# snips-nlu/spotify-1488
 U: Play any song from the eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1499
+# snips-nlu/spotify-1499
 U: Play me a 1990 sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1990, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1990, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1503
+# snips-nlu/spotify-1503
 U: play Barry Manilow from the twenties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "barry manilow") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("barry manilow")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1514
+# snips-nlu/spotify-1514
 U: play the best album from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1515
-U: Play music from 2016.
+# snips-nlu/spotify-1515
+U: Play music from 2016 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1525
+# snips-nlu/spotify-1525
 U: I want to listen to seventies music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1533
+# snips-nlu/spotify-1533
 U: Play music from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1537
-U: Play sixties music by giovanni battista guadagnini.
+# snips-nlu/spotify-1537
+U: Play sixties music by giovanni battista guadagnini .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) && contains~(artists, "giovanni battista guadagnini") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) && contains(artists, null^^com.spotify:artist("giovanni battista guadagnini")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1563
+# snips-nlu/spotify-1563
 U: play some songs from the fourties by yoshiki fukuyama
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains~(artists, "yoshiki fukuyama") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains(artists, null^^com.spotify:artist("yoshiki fukuyama")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1567
+# snips-nlu/spotify-1567
 U: play music by Charlie Adams from 1954
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "charlie adams") && release_date >= makeDate(1954, 1, 1) && release_date <= makeDate(1954, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("charlie adams")) && release_date >= makeDate(1954, 1, 1) && release_date <= makeDate(1954, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1571
+# snips-nlu/spotify-1571
 U: Play a 2001 tune
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2001, 1, 1) && release_date <= makeDate(2001, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2001, 1, 1) && release_date <= makeDate(2001, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1601
+# snips-nlu/spotify-1601
 U: play some fifties tunes by Mike Mccready
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "mike mccready") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("mike mccready")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1609
+# snips-nlu/spotify-1609
 U: Play Gary Chapman music from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "gary chapman") && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("gary chapman")) && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1610
+# snips-nlu/spotify-1610
 U: Play some Armik from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "armik") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("armik")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1611
+# snips-nlu/spotify-1611
 U: play a popular sort of fifties tune music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1613
-U: Play music from 1989 by Maya.
+# snips-nlu/spotify-1613
+U: Play music from 1989 by Maya .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1989, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains~(artists, "maya") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1989, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains(artists, null^^com.spotify:artist("maya")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1618
-U: Play Arif music from the fourties.
+# snips-nlu/spotify-1618
+U: Play Arif music from the fourties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "arif") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("arif")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1623
+# snips-nlu/spotify-1623
 U: Play paul ortiz music from 1990
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "paul ortiz") && release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1990, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("paul ortiz")) && release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1990, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1631
-U: Proceed with music from 2003.
+# snips-nlu/spotify-1631
+U: Proceed with music from 2003 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1632
+# snips-nlu/spotify-1632
 U: Play Elkie Brooks seventies sound track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "elkie brooks") && release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("elkie brooks")) && release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1640
+# snips-nlu/spotify-1640
 U: Play some caribou from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "caribou") && release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("caribou")) && release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1650
+# snips-nlu/spotify-1650
 U: Play all music Alan released in 1997
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "alan") && release_date >= makeDate(1997, 1, 1) && release_date <= makeDate(1997, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("alan")) && release_date >= makeDate(1997, 1, 1) && release_date <= makeDate(1997, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1655
+# snips-nlu/spotify-1655
 U: play some sixties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1657
+# snips-nlu/spotify-1657
 U: Play music year 2016 by artist Michiru Yamane
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) && contains~(artists, "michiru yamane") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2016, 1, 1) && release_date <= makeDate(2016, 12, 31) && contains(artists, null^^com.spotify:artist("michiru yamane")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1673
+# snips-nlu/spotify-1673
 U: play eighties track
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1674
+# snips-nlu/spotify-1674
 U: Wish to hear music from the year 1996
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1996, 1, 1) && release_date <= makeDate(1996, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1685
+# snips-nlu/spotify-1685
 U: Play some Paul Stookey from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "paul stookey") && release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("paul stookey")) && release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1692
-U: I want to hear a track from the fourties.
+# snips-nlu/spotify-1692
+U: I want to hear a track from the fourties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1709
+# snips-nlu/spotify-1709
 U: Play some seventies track from top Rie Tomosaka
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains~(artists, "rie tomosaka") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) && contains(artists, null^^com.spotify:artist("rie tomosaka")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1714
+# snips-nlu/spotify-1714
 U: Please play a song for me from 1959
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1959, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1959, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1718
+# snips-nlu/spotify-1718
 U: Play me a fifties song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1746
-U: I wish to listen to eighties music by Mike Dean.
+# snips-nlu/spotify-1746
+U: I wish to listen to eighties music by Mike Dean .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains~(artists, "mike dean") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains(artists, null^^com.spotify:artist("mike dean")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1751
+# snips-nlu/spotify-1751
 U: Play a 1991 song by Anila Mirza
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) && contains~(artists, "anila mirza") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) && contains(artists, null^^com.spotify:artist("anila mirza")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1758
-U: Play some 2011 music by Dan Healy.
+# snips-nlu/spotify-1758
+U: Play some 2011 music by Dan Healy .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2011, 1, 1) && release_date <= makeDate(2011, 12, 31) && contains~(artists, "dan healy") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2011, 1, 1) && release_date <= makeDate(2011, 12, 31) && contains(artists, null^^com.spotify:artist("dan healy")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1761
+# snips-nlu/spotify-1761
 U: Listen to music from 1975
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1975, 1, 1) && release_date <= makeDate(1975, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1764
+# snips-nlu/spotify-1764
 U: play a tune from 2000 by Bronislau Kaper
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2000, 1, 1) && release_date <= makeDate(2000, 12, 31) && contains~(artists, "bronislau kaper") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2000, 1, 1) && release_date <= makeDate(2000, 12, 31) && contains(artists, null^^com.spotify:artist("bronislau kaper")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1765
-U: Play a song from 1994.
+# snips-nlu/spotify-1765
+U: Play a song from 1994 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1773
-U: Play a top-50 tune from 1982.
+# snips-nlu/spotify-1773
+U: Play a top-50 tune from 1982 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1982, 1, 1) && release_date <= makeDate(1982, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1982, 1, 1) && release_date <= makeDate(1982, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1777
+# snips-nlu/spotify-1777
 U: play the music track of 1998
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1998, 1, 1) && release_date <= makeDate(1998, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1998, 1, 1) && release_date <= makeDate(1998, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1778
+# snips-nlu/spotify-1778
 U: Play some music by Jody Williams from 2001
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "jody williams") && release_date >= makeDate(2001, 1, 1) && release_date <= makeDate(2001, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("jody williams")) && release_date >= makeDate(2001, 1, 1) && release_date <= makeDate(2001, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1787
+# snips-nlu/spotify-1787
 U: I'm looking for the last track by Fei Yu Ching from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "fei yu ching") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fei yu ching")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1793
+# snips-nlu/spotify-1793
 U: Play a song from 1950
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1950, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1950, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1795
+# snips-nlu/spotify-1795
 U: play a new song from the seventies
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1803
+# snips-nlu/spotify-1803
 U: Play some ivy anderson from around 1967
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "ivy anderson") && release_date >= makeDate(1967, 1, 1) && release_date <= makeDate(1967, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("ivy anderson")) && release_date >= makeDate(1967, 1, 1) && release_date <= makeDate(1967, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1804
+# snips-nlu/spotify-1804
 U: play the newest sound track from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1808
+# snips-nlu/spotify-1808
 U: play some sad songs from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1816
+# snips-nlu/spotify-1816
 U: play twenties tunes
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1823
+# snips-nlu/spotify-1823
 U: Play music from 1958
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1958, 1, 1) && release_date <= makeDate(1958, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1828
-U: Play music from 1964.
+# snips-nlu/spotify-1828
+U: Play music from 1964 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1964, 1, 1) && release_date <= makeDate(1964, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1847
+# snips-nlu/spotify-1841
+U: Play a rock track from 1984
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: now => @com.spotify.song(), contains~(genres, "rock") && release_date >= makeDate(1984, 1, 1) && release_date <= makeDate(1984, 12, 31) => @com.spotify.play_song(song=id);
+====
+# snips-nlu/spotify-1847
 U: Play a 2007 track from Adam Jones
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) && contains~(artists, "adam jones") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) && contains(artists, null^^com.spotify:artist("adam jones")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1856
+# snips-nlu/spotify-1856
 U: Can you play some fifties music by lavern baker
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "lavern baker") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("lavern baker")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1858
+# snips-nlu/spotify-1858
 U: play anything from 1970
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1970, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1859
-U: I wish to enjoy some fifties music by Johnny Paycheck.
+# snips-nlu/spotify-1859
+U: I wish to enjoy some fifties music by Johnny Paycheck .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "johnny paycheck") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("johnny paycheck")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1861
+# snips-nlu/spotify-1861
 U: Play me a seventies song
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1970, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1869
+# snips-nlu/spotify-1869
 U: Play best fourties from david izquierdo on album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains~(artists, "david izquierdo") => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => sort popularity desc of @com.spotify.album(), release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) && contains(artists, null^^com.spotify:artist("david izquierdo")) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-1885
+# snips-nlu/spotify-1885
 U: Play music from 2015
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2015, 1, 1) && release_date <= makeDate(2015, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1887
+# snips-nlu/spotify-1887
 U: Play me a song by Carol Arnauld from 2003
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "carol arnauld") && release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("carol arnauld")) && release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1890
-U: Please play me a popular track from 1984.
+# snips-nlu/spotify-1890
+U: Please play me a popular track from 1984 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1984, 1, 1) && release_date <= makeDate(1984, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort popularity desc of @com.spotify.song(), release_date >= makeDate(1984, 1, 1) && release_date <= makeDate(1984, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1905
+# snips-nlu/spotify-1905
 U: Can you play some music from 1999
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1999, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1999, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1907
+# snips-nlu/spotify-1907
 U: play some King Tubby from the eighties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "king tubby") && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("king tubby")) && release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1909
-U: Play Randy Castillo's music from 1952.
+# snips-nlu/spotify-1909
+U: Play Randy Castillo's music from 1952 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "randy castillo") && release_date >= makeDate(1952, 1, 1) && release_date <= makeDate(1952, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("randy castillo")) && release_date >= makeDate(1952, 1, 1) && release_date <= makeDate(1952, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1920
+# snips-nlu/spotify-1920
 U: Play me a 1986 Jim Root
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) && contains~(artists, "jim root") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) && contains(artists, null^^com.spotify:artist("jim root")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1927
+# snips-nlu/spotify-1927
 U: play a tune from 1973
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1933
+# snips-nlu/spotify-1933
 U: play Yusef Lateef songs from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "yusef lateef") && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("yusef lateef")) && release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1951
-U: I want to hear music from the sixties.
+# snips-nlu/spotify-1951
+U: I want to hear music from the sixties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1958
+# snips-nlu/spotify-1958
 U: Play me some music from 1999
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1999, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1999, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1963
+# snips-nlu/spotify-1963
 U: play the last song from the thirties by Airto Moreira
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains~(artists, "airto moreira") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains(artists, null^^com.spotify:artist("airto moreira")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1968
+# snips-nlu/spotify-1968
 U: play Luis Alfonzo Larrain from 1995
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "luis alfonzo larrain") && release_date >= makeDate(1995, 1, 1) && release_date <= makeDate(1995, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("luis alfonzo larrain")) && release_date >= makeDate(1995, 1, 1) && release_date <= makeDate(1995, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1972
+# snips-nlu/spotify-1972
 U: play some music from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1983
-U: Play some music from 1989 by Sanjeev Abhyankar.
+# snips-nlu/spotify-1983
+U: Play some music from 1989 by Sanjeev Abhyankar .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1989, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains~(artists, "sanjeev abhyankar") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1989, 1, 1) && release_date <= makeDate(1989, 12, 31) && contains(artists, null^^com.spotify:artist("sanjeev abhyankar")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1986
+# snips-nlu/spotify-1986
 U: play music from the year 1979
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1979, 1, 1) && release_date <= makeDate(1979, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1979, 1, 1) && release_date <= makeDate(1979, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1993
+# snips-nlu/spotify-1993
 U: Play music from 1954
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1954, 1, 1) && release_date <= makeDate(1954, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1954, 1, 1) && release_date <= makeDate(1954, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-1997
+# snips-nlu/spotify-1997
 U: play 2007 tunes by Bunny Berigan
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) && contains~(artists, "bunny berigan") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) && contains(artists, null^^com.spotify:artist("bunny berigan")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2005
+# snips-nlu/spotify-2005
 U: Song from Brian Chase in 2004
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "brian chase") && release_date >= makeDate(2004, 1, 1) && release_date <= makeDate(2004, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("brian chase")) && release_date >= makeDate(2004, 1, 1) && release_date <= makeDate(2004, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2006
+# snips-nlu/spotify-2006
 U: give me something from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2015
-U: Play music from Sleepy John Estes from 2002.
+# snips-nlu/spotify-2015
+U: Play music from Sleepy John Estes from 2002 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "sleepy john estes") && release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("sleepy john estes")) && release_date >= makeDate(2002, 1, 1) && release_date <= makeDate(2002, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2016
-U: Play a sound track from 1952.
+# snips-nlu/spotify-2016
+U: Play a sound track from 1952 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1952, 1, 1) && release_date <= makeDate(1952, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1952, 1, 1) && release_date <= makeDate(1952, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2028
+# snips-nlu/spotify-2028
 U: I wish to listen to some fifties music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2037
-U: Play music from the thirties by Swjatoslaw Wakartschuk.
+# snips-nlu/spotify-2037
+U: Play music from the thirties by Swjatoslaw Wakartschuk .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains~(artists, "swjatoslaw wakartschuk") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains(artists, null^^com.spotify:artist("swjatoslaw wakartschuk")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2040
+# snips-nlu/spotify-2040
 U: Can you play nineties music from Paul Kelly?
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "paul kelly") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("paul kelly")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2044
-U: Play a tune from 2007.
+# snips-nlu/spotify-2044
+U: Play a tune from 2007 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(2007, 1, 1) && release_date <= makeDate(2007, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2049
+# snips-nlu/spotify-2049
 U: Play some 1988 Harry T. Burleigh
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1988, 1, 1) && release_date <= makeDate(1988, 12, 31) && contains~(artists, "harry t. burleigh") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1988, 1, 1) && release_date <= makeDate(1988, 12, 31) && contains(artists, null^^com.spotify:artist("harry t. burleigh")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2052
+# snips-nlu/spotify-2052
 U: Please play a track from the nineties by any artist
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2054
+# snips-nlu/spotify-2054
 U: let's listen to the 1986 sound track by Mike Park
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) && contains~(artists, "mike park") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) && contains(artists, null^^com.spotify:artist("mike park")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2065
+# snips-nlu/spotify-2065
 U: play music from 1974
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1974, 1, 1) && release_date <= makeDate(1974, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1974, 1, 1) && release_date <= makeDate(1974, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2078
+# snips-nlu/spotify-2078
 U: I would like to hear music from 1993
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1993, 1, 1) && release_date <= makeDate(1993, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1993, 1, 1) && release_date <= makeDate(1993, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2090
-U: Play some nineties stuff from Clem Burke.
+# snips-nlu/spotify-2090
+U: Play some nineties stuff from Clem Burke .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "clem burke") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("clem burke")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2102
-U: Play a song from 1994.
+# snips-nlu/spotify-2102
+U: Play a song from 1994 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1994, 1, 1) && release_date <= makeDate(1994, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2105
+# snips-nlu/spotify-2105
 U: Please play something from the fifties by Roscoe
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "roscoe") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("roscoe")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2130
-U: Please play some nineties music by Tommy Johnson.
+# snips-nlu/spotify-2130
+U: Please play some nineties music by Tommy Johnson .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "tommy johnson") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("tommy johnson")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2133
+# snips-nlu/spotify-2133
 U: Play something by the artist Jenifer from 2003
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "jenifer") && release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("jenifer")) && release_date >= makeDate(2003, 1, 1) && release_date <= makeDate(2003, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2136
+# snips-nlu/spotify-2136
 U: Play music from Stacy Ferguson from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "stacy ferguson") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("stacy ferguson")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2146
+# snips-nlu/spotify-2146
 U: I want to hear an album from 2010
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(2010, 1, 1) && release_date <= makeDate(2010, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(2010, 1, 1) && release_date <= makeDate(2010, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2152
+# snips-nlu/spotify-2152
 U: I want to hear music from carman from the 1966 album
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), contains~(artists, "carman") && release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), contains(artists, null^^com.spotify:artist("carman")) && release_date >= makeDate(1966, 1, 1) && release_date <= makeDate(1966, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2153
+# snips-nlu/spotify-2153
 U: Play some twenties music
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2154
+# snips-nlu/spotify-2154
 U: Play some 1983 Jon Brooks
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1983, 1, 1) && release_date <= makeDate(1983, 12, 31) && contains~(artists, "jon brooks") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1983, 1, 1) && release_date <= makeDate(1983, 12, 31) && contains(artists, null^^com.spotify:artist("jon brooks")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2164
-U: Play a tune from 1973.
+# snips-nlu/spotify-2164
+U: Play a tune from 1973 .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1973, 1, 1) && release_date <= makeDate(1973, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2165
-U: Play Arif music from the fourties.
+# snips-nlu/spotify-2165
+U: Play Arif music from the fourties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "arif") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("arif")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2168
+# snips-nlu/spotify-2168
 U: I'm looking for the last track by Fei Yu Ching from the fourties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => sort release_date desc of @com.spotify.song(), contains~(artists, "fei yu ching") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => sort release_date desc of @com.spotify.song(), contains(artists, null^^com.spotify:artist("fei yu ching")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2171
+# snips-nlu/spotify-2171
 U: Play me a track from the sixties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2176
+# snips-nlu/spotify-2176
 U: play me something from the fifties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2187
+# snips-nlu/spotify-2187
 U: Play nineties music.
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2188
+# snips-nlu/spotify-2188
 U: Play a song from the thirties by Bruno Pelletier
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains~(artists, "bruno pelletier") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains(artists, null^^com.spotify:artist("bruno pelletier")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2190
-U: We want to listen to nineties music from mike burkett.
+# snips-nlu/spotify-2190
+U: We want to listen to nineties music from mike burkett .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "mike burkett") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("mike burkett")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2192
-U: Please play some nineties music album.
+# snips-nlu/spotify-2192
+U: Please play some nineties music album .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.album(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => notify;
-UT: now => @com.spotify.play_album(album=$?);
+UT: now => @com.spotify.album(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) => @com.spotify.play_album(album=id);
 ====
-# nlu/spotify-2194
-U: I want to hear music from the sixties.
+# snips-nlu/spotify-2194
+U: I want to hear music from the sixties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1960, 1, 1) && release_date <= makeDate(1969, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2196
+# snips-nlu/spotify-2196
 U: play some music from the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2209
-U: I wish to enjoy some fifties music by Johnny Paycheck.
+# snips-nlu/spotify-2209
+U: I wish to enjoy some fifties music by Johnny Paycheck .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains~(artists, "johnny paycheck") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1950, 1, 1) && release_date <= makeDate(1959, 12, 31) && contains(artists, null^^com.spotify:artist("johnny paycheck")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2213
+# snips-nlu/spotify-2213
 U: Something by Danielle Polanco in 1986
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "danielle polanco") && release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("danielle polanco")) && release_date >= makeDate(1986, 1, 1) && release_date <= makeDate(1986, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2222
-U: I want to hear Eddi Reader from the twenties.
+# snips-nlu/spotify-2222
+U: I want to hear Eddi Reader from the twenties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "eddi reader") && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("eddi reader")) && release_date >= makeDate(1920, 1, 1) && release_date <= makeDate(1929, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2239
+# snips-nlu/spotify-2239
 U: play something from 1971 by John Bonham
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1971, 1, 1) && release_date <= makeDate(1971, 12, 31) && contains~(artists, "john bonham") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1971, 1, 1) && release_date <= makeDate(1971, 12, 31) && contains(artists, null^^com.spotify:artist("john bonham")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2266
-U: Play music from the thirties.
+# snips-nlu/spotify-2266
+U: Play music from the thirties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2269
+# snips-nlu/spotify-2269
 U: An interesting piece from 1991 please
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1991, 1, 1) && release_date <= makeDate(1991, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2271
-U: Play Device music from the fourties.
+# snips-nlu/spotify-2271
+U: Play Device music from the fourties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "device") && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("device")) && release_date >= makeDate(1940, 1, 1) && release_date <= makeDate(1949, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2284
+# snips-nlu/spotify-2284
 U: I want to listen to martina mcbride music from 1995
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "martina mcbride") && release_date >= makeDate(1995, 1, 1) && release_date <= makeDate(1995, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("martina mcbride")) && release_date >= makeDate(1995, 1, 1) && release_date <= makeDate(1995, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2290
+# snips-nlu/spotify-2290
 U: Start playing anything Mike Muir made in the thirties
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), contains~(artists, "mike muir") && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), contains(artists, null^^com.spotify:artist("mike muir")) && release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2291
+# snips-nlu/spotify-2291
 U: Play some thirties Frank Wildhorn
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains~(artists, "frank wildhorn") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1930, 1, 1) && release_date <= makeDate(1939, 12, 31) && contains(artists, null^^com.spotify:artist("frank wildhorn")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2293
+# snips-nlu/spotify-2293
 U: Play music from 1972
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1972, 1, 1) && release_date <= makeDate(1972, 12, 31) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2294
+# snips-nlu/spotify-2294
 U: I want to play a song from the nineties by Roddy Woomble
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains~(artists, "roddy woomble") => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1990, 1, 1) && release_date <= makeDate(1999, 12, 31) && contains(artists, null^^com.spotify:artist("roddy woomble")) => @com.spotify.play_song(song=id);
 ====
-# nlu/spotify-2297
-U: Play music from the eighties.
+# snips-nlu/spotify-2297
+U: Play music from the eighties .
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => notify;
-UT: now => @com.spotify.play_song(song=$?);
+UT: now => @com.spotify.song(), release_date >= makeDate(1980, 1, 1) && release_date <= makeDate(1989, 12, 31) => @com.spotify.play_song(song=id);

--- a/main/com.spotify/index.js
+++ b/main/com.spotify/index.js
@@ -499,7 +499,7 @@ module.exports = class SpotifyDevice extends Tp.BaseDevice {
         console.log("CAN PLAY: " + canPlay);
         console.log(typeof canPlay);
         if (typeof canPlay === 'boolean' && canPlay) return this.http_post_default_options(QUEUE_URL + `?uri=${uri}`, '');
-        else return this.http_post_default_options(QUEUE_URL + `?uri=${uri}`, '');
+        else return this.http_post_default_options(QUEUE_URL + `?device_id=${canPlay}` + `?uri=${uri}`, '');
     }
 
     async currently_playing_helper() {

--- a/main/com.spotify/manifest.tt
+++ b/main/com.spotify/manifest.tt
@@ -73,6 +73,15 @@ class @com.spotify
                       passive_verb=["written by #", "released by #", "produced by #"],
                       verb = ["# wrote", "# released", "# produced"]
                     }],
+                    out genres: Array(String)
+                    #_[canonical={
+                      default="adjective",
+                      base=["genres", "music", "type of genre", "type of music", "category"],
+                      property=["# songs", "# music"],
+                      adjective=["#"],
+                      preposition=["in the # genre", "in #"],
+                      passive_verb=["played # music", "played the # genre"]
+                    }],
                     out release_date : Date
                     #_[canonical={
                       default="preposition",

--- a/main/com.spotify/simulation/spotify_db.json
+++ b/main/com.spotify/simulation/spotify_db.json
@@ -1,6 +1,29 @@
 [
     {
         "id": {
+            "value": "spotify:track:2r6OAV3WsYtXuXjvJ1lIDi",
+            "display": "Hello (feat. A Boogie Wit da Hoodie)"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:0eDvMgVFoNV3TpwtrVCoTj",
+                "display": "Pop Smoke"
+            },
+            {
+                "value": "spotify:artist:31W5EY0aAly4Qieq6OFu6I",
+                "display": "A Boogie Wit da Hoodie"
+            }
+        ],
+        "genres": [
+            "brooklyn drill"
+        ],
+        "release_date": "2020-07-20",
+        "popularity": 73,
+        "energy": 64,
+        "danceability": 90
+    },
+    {
+        "id": {
             "value": "spotify:track:7qwt4xUIqQWCu1DJf96g2k",
             "display": "Hello?"
         },
@@ -13,6 +36,11 @@
                 "value": "spotify:artist:3lLHpTOJ11tWiUNGYN14gt",
                 "display": "Rejjie Snow"
             }
+        ],
+        "genres": [
+            "bedroom pop",
+            "boston indie",
+            "indie pop"
         ],
         "release_date": "2018-05-25",
         "popularity": 74,
@@ -30,8 +58,13 @@
                 "display": "Adele"
             }
         ],
+        "genres": [
+            "british soul",
+            "pop",
+            "uk pop"
+        ],
         "release_date": "2016-06-24",
-        "popularity": 71,
+        "popularity": 72,
         "energy": 45,
         "danceability": 48
     },
@@ -46,8 +79,16 @@
                 "display": "ROLE MODEL"
             }
         ],
+        "genres": [
+            "alternative r&b",
+            "bedroom pop",
+            "indie cafe pop",
+            "indie pop",
+            "indie r&b",
+            "pop"
+        ],
         "release_date": "2019-11-13",
-        "popularity": 63,
+        "popularity": 64,
         "energy": 46,
         "danceability": 79
     },
@@ -61,6 +102,14 @@
                 "value": "spotify:artist:3Fe3pszR2t4TOBVz41B1WR",
                 "display": "The Oh Hellos"
             }
+        ],
+        "genres": [
+            "folk-pop",
+            "indie folk",
+            "indiecoustica",
+            "san marcos tx indie",
+            "shimmer pop",
+            "stomp and holler"
         ],
         "release_date": "2011-12-01",
         "popularity": 64,
@@ -78,6 +127,10 @@
                 "display": "Noah Schnacky"
             }
         ],
+        "genres": [
+            "contemporary country",
+            "country pop"
+        ],
         "release_date": "2018-01-27",
         "popularity": 63,
         "energy": 47,
@@ -93,6 +146,14 @@
                 "value": "spotify:artist:3gMaNLQm7D9MornNILzdSl",
                 "display": "Lionel Richie"
             }
+        ],
+        "genres": [
+            "adult standards",
+            "disco",
+            "mellow gold",
+            "motown",
+            "quiet storm",
+            "soft rock"
         ],
         "release_date": "1983-01-01",
         "popularity": 59,
@@ -110,9 +171,15 @@
                 "display": "J. Cole"
             }
         ],
+        "genres": [
+            "conscious hip hop",
+            "hip hop",
+            "north carolina hip hop",
+            "rap"
+        ],
         "release_date": "2014-12-09",
         "popularity": 59,
-        "energy": 7,
+        "energy": 70,
         "danceability": 63
     },
     {
@@ -126,30 +193,14 @@
                 "display": "Conway Twitty"
             }
         ],
+        "genres": [
+            "arkansas country",
+            "country"
+        ],
         "release_date": "1970-03-23",
         "popularity": 60,
         "energy": 23,
         "danceability": 27
-    },
-    {
-        "id": {
-            "value": "spotify:track:7bza6R254w7hZyNO9zaIxc",
-            "display": "Hello"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:5jZeLexrrwGNUy6nv7tzdr",
-                "display": "C4C"
-            },
-            {
-                "value": "spotify:artist:1uJZwuCV2hXbQDSdJvj198",
-                "display": "kokoro"
-            }
-        ],
-        "release_date": "2020-02-14",
-        "popularity": 61,
-        "energy": 21,
-        "danceability": 64
     },
     {
         "id": {
@@ -162,26 +213,18 @@
                 "display": "The Beatles"
             }
         ],
+        "genres": [
+            "beatlesque",
+            "british invasion",
+            "classic rock",
+            "merseybeat",
+            "psychedelic rock",
+            "rock"
+        ],
         "release_date": "1967-11-27",
-        "popularity": 65,
+        "popularity": 66,
         "energy": 73,
         "danceability": 47
-    },
-    {
-        "id": {
-            "value": "spotify:track:127QTOFJsJQp5LbJbu3A1y",
-            "display": "Toosie Slide"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
-                "display": "Drake"
-            }
-        ],
-        "release_date": "2020-04-03",
-        "popularity": 93,
-        "energy": 45,
-        "danceability": 83
     },
     {
         "id": {
@@ -198,10 +241,42 @@
                 "display": "Giveon"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2020-05-01",
         "popularity": 88,
         "energy": 44,
         "danceability": 73
+    },
+    {
+        "id": {
+            "value": "spotify:track:127QTOFJsJQp5LbJbu3A1y",
+            "display": "Toosie Slide"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
+                "display": "Drake"
+            }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
+        "release_date": "2020-04-03",
+        "popularity": 92,
+        "energy": 45,
+        "danceability": 83
     },
     {
         "id": {
@@ -218,10 +293,42 @@
                 "display": "Rick Ross"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2019-06-15",
         "popularity": 84,
         "energy": 50,
         "danceability": 83
+    },
+    {
+        "id": {
+            "value": "spotify:track:6DCZcSspjsKoFjzjrWoCdn",
+            "display": "God's Plan"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
+                "display": "Drake"
+            }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
+        "release_date": "2018-06-29",
+        "popularity": 84,
+        "energy": 44,
+        "danceability": 75
     },
     {
         "id": {
@@ -238,26 +345,18 @@
                 "display": "Playboi Carti"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2020-05-01",
-        "popularity": 80,
+        "popularity": 79,
         "energy": 37,
         "danceability": 82
-    },
-    {
-        "id": {
-            "value": "spotify:track:6DCZcSspjsKoFjzjrWoCdn",
-            "display": "God's Plan"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
-                "display": "Drake"
-            }
-        ],
-        "release_date": "2018-06-29",
-        "popularity": 84,
-        "energy": 44,
-        "danceability": 75
     },
     {
         "id": {
@@ -269,6 +368,14 @@
                 "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
                 "display": "Drake"
             }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
         ],
         "release_date": "2020-05-01",
         "popularity": 86,
@@ -286,6 +393,14 @@
                 "display": "Drake"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2018-06-29",
         "popularity": 80,
         "energy": 41,
@@ -301,6 +416,14 @@
                 "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
                 "display": "Drake"
             }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
         ],
         "release_date": "2018-06-29",
         "popularity": 79,
@@ -318,6 +441,14 @@
                 "display": "Drake"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2017-03-18",
         "popularity": 80,
         "energy": 46,
@@ -334,50 +465,18 @@
                 "display": "Drake"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2018-06-29",
         "popularity": 81,
         "energy": 62,
         "danceability": 83
-    },
-    {
-        "id": {
-            "value": "spotify:track:5H4mXWKcicuLKDn4Jy0sK7",
-            "display": "Time Flies"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
-                "display": "Drake"
-            }
-        ],
-        "release_date": "2020-05-01",
-        "popularity": 76,
-        "energy": 47,
-        "danceability": 86
-    },
-    {
-        "id": {
-            "value": "spotify:track:05aZ9sAU1YXndHv0FMi9iW",
-            "display": "Demons (feat. Fivio Foreign & Sosa Geek)"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
-                "display": "Drake"
-            },
-            {
-                "value": "spotify:artist:14CHVeJGrR5xgUGQFV5BVM",
-                "display": "Fivio Foreign"
-            },
-            {
-                "value": "spotify:artist:2UyyBkpzN5w3hzZBZGvRZb",
-                "display": "Sosa Geek"
-            }
-        ],
-        "release_date": "2020-05-01",
-        "popularity": 75,
-        "energy": 76,
-        "danceability": 54
     },
     {
         "id": {
@@ -390,10 +489,42 @@
                 "display": "Drake"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2011-11-15",
         "popularity": 74,
         "energy": 26,
         "danceability": 49
+    },
+    {
+        "id": {
+            "value": "spotify:track:5H4mXWKcicuLKDn4Jy0sK7",
+            "display": "Time Flies"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
+                "display": "Drake"
+            }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
+        "release_date": "2020-05-01",
+        "popularity": 76,
+        "energy": 47,
+        "danceability": 86
     },
     {
         "id": {
@@ -414,6 +545,14 @@
                 "display": "Kyla"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2016-05-06",
         "popularity": 81,
         "energy": 62,
@@ -421,8 +560,8 @@
     },
     {
         "id": {
-            "value": "spotify:track:7eYAHC0RbBF9eaqWzT34Aq",
-            "display": "Desires (with Future)"
+            "value": "spotify:track:05aZ9sAU1YXndHv0FMi9iW",
+            "display": "Demons (feat. Fivio Foreign & Sosa Geek)"
         },
         "artists": [
             {
@@ -430,14 +569,26 @@
                 "display": "Drake"
             },
             {
-                "value": "spotify:artist:1RyvyyTE3xzB2ZywiAwp0i",
-                "display": "Future"
+                "value": "spotify:artist:14CHVeJGrR5xgUGQFV5BVM",
+                "display": "Fivio Foreign"
+            },
+            {
+                "value": "spotify:artist:2UyyBkpzN5w3hzZBZGvRZb",
+                "display": "Sosa Geek"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2020-05-01",
-        "popularity": 75,
-        "energy": 50,
-        "danceability": 81
+        "popularity": 74,
+        "energy": 76,
+        "danceability": 54
     },
     {
         "id": {
@@ -449,6 +600,14 @@
                 "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
                 "display": "Drake"
             }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
         ],
         "release_date": "2017-03-18",
         "popularity": 74,
@@ -470,10 +629,46 @@
                 "display": "Lil Wayne"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2011-11-15",
         "popularity": 72,
         "energy": 44,
         "danceability": 76
+    },
+    {
+        "id": {
+            "value": "spotify:track:7eYAHC0RbBF9eaqWzT34Aq",
+            "display": "Desires (with Future)"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
+                "display": "Drake"
+            },
+            {
+                "value": "spotify:artist:1RyvyyTE3xzB2ZywiAwp0i",
+                "display": "Future"
+            }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
+        "release_date": "2020-05-01",
+        "popularity": 74,
+        "energy": 50,
+        "danceability": 81
     },
     {
         "id": {
@@ -490,6 +685,14 @@
                 "display": "Majid Jordan"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2013-01-01",
         "popularity": 70,
         "energy": 41,
@@ -505,6 +708,14 @@
                 "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
                 "display": "Drake"
             }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
         ],
         "release_date": "2017-03-18",
         "popularity": 74,
@@ -526,10 +737,426 @@
                 "display": "Future"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2015-09-20",
         "popularity": 73,
         "energy": 55,
         "danceability": 85
+    },
+    {
+        "id": {
+            "value": "spotify:track:4R2kfaDFhslZEMJqAFNpdd",
+            "display": "cardigan"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 89,
+        "energy": 58,
+        "danceability": 61
+    },
+    {
+        "id": {
+            "value": "spotify:track:0Jlcvv8IykzHaSmj49uNW8",
+            "display": "the 1"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 88,
+        "energy": 35,
+        "danceability": 77
+    },
+    {
+        "id": {
+            "value": "spotify:track:4pvb0WLRcMtbPGmtejJJ6y",
+            "display": "exile (feat. Bon Iver)"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            },
+            {
+                "value": "spotify:artist:4LEiUm1SRbFMgfqnQTwUbQ",
+                "display": "Bon Iver"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 88,
+        "energy": 38,
+        "danceability": 29
+    },
+    {
+        "id": {
+            "value": "spotify:track:2Eeur20xVqfUoM3Q7EFPFt",
+            "display": "the last great american dynasty"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 86,
+        "energy": 66,
+        "danceability": 68
+    },
+    {
+        "id": {
+            "value": "spotify:track:1MgV7FIyNxIG7WzMRJV5HC",
+            "display": "my tears ricochet"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 86,
+        "energy": 26,
+        "danceability": 45
+    },
+    {
+        "id": {
+            "value": "spotify:track:3hUxzQpSfdDqwM3ZTFQY0K",
+            "display": "august"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 85,
+        "energy": 62,
+        "danceability": 53
+    },
+    {
+        "id": {
+            "value": "spotify:track:0ZNU020wNYvgW84iljPkPP",
+            "display": "mirrorball"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 85,
+        "energy": 41,
+        "danceability": 55
+    },
+    {
+        "id": {
+            "value": "spotify:track:6KJqZcs9XDgVck7Lg9QOTC",
+            "display": "seven"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 84,
+        "energy": 48,
+        "danceability": 59
+    },
+    {
+        "id": {
+            "value": "spotify:track:6VsvKPJ4xjVNKpI8VVZ3SV",
+            "display": "invisible string"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 84,
+        "energy": 45,
+        "danceability": 65
+    },
+    {
+        "id": {
+            "value": "spotify:track:7kt9e9LFSpN1zQtYEl19o1",
+            "display": "this is me trying"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 84,
+        "energy": 47,
+        "danceability": 51
+    },
+    {
+        "id": {
+            "value": "spotify:track:2NmsngXHeC1GQ9wWrzhOMf",
+            "display": "illicit affairs"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 84,
+        "energy": 31,
+        "danceability": 55
+    },
+    {
+        "id": {
+            "value": "spotify:track:5kI4eCXXzyuIUXjQra0Cxi",
+            "display": "betty"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 83,
+        "energy": 37,
+        "danceability": 59
+    },
+    {
+        "id": {
+            "value": "spotify:track:2QDyYdZyhlP2fp79KZX8Bi",
+            "display": "mad woman"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 83,
+        "energy": 69,
+        "danceability": 59
+    },
+    {
+        "id": {
+            "value": "spotify:track:08fa9LFcFBTcilB3iq2e2A",
+            "display": "epiphany"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 82,
+        "energy": 26,
+        "danceability": 35
+    },
+    {
+        "id": {
+            "value": "spotify:track:7MbT4I8qGntX4fMdqMQgke",
+            "display": "peace"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 82,
+        "energy": 27,
+        "danceability": 64
+    },
+    {
+        "id": {
+            "value": "spotify:track:6MWoRt97mnSTXZhu3ggi9C",
+            "display": "hoax"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 81,
+        "energy": 18,
+        "danceability": 66
+    },
+    {
+        "id": {
+            "value": "spotify:track:6RRNNciQGZEXnqk8SQ9yv5",
+            "display": "You Need To Calm Down"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2019-08-23",
+        "popularity": 83,
+        "energy": 67,
+        "danceability": 77
+    },
+    {
+        "id": {
+            "value": "spotify:track:4LEK9rD7TWIG4FCL1s27XC",
+            "display": "cardigan"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 73,
+        "energy": 58,
+        "danceability": 61
+    },
+    {
+        "id": {
+            "value": "spotify:track:59HA1SBz1DPCCvdDeILV7E",
+            "display": "exile (feat. Bon Iver)"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            },
+            {
+                "value": "spotify:artist:4LEiUm1SRbFMgfqnQTwUbQ",
+                "display": "Bon Iver"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 68,
+        "energy": 38,
+        "danceability": 29
+    },
+    {
+        "id": {
+            "value": "spotify:track:2b4dRZGflAQT7ZbFwOclyP",
+            "display": "the 1"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:06HL4z0CvFAxyc27GXpf02",
+                "display": "Taylor Swift"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 65,
+        "energy": 34,
+        "danceability": 76
     },
     {
         "id": {
@@ -545,6 +1172,12 @@
                 "value": "spotify:artist:4VMYDCV2IEDYJArk749S6m",
                 "display": "Daddy Yankee"
             }
+        ],
+        "genres": [
+            "latin",
+            "latin pop",
+            "puerto rican pop",
+            "tropical"
         ],
         "release_date": "2019-02-01",
         "popularity": 79,
@@ -570,10 +1203,38 @@
                 "display": "Justin Bieber"
             }
         ],
+        "genres": [
+            "latin",
+            "latin pop",
+            "puerto rican pop",
+            "tropical"
+        ],
         "release_date": "2017-04-17",
         "popularity": 74,
         "energy": 81,
         "danceability": 65
+    },
+    {
+        "id": {
+            "value": "spotify:track:5Uu62434DzHMnUupX7XTZY",
+            "display": "Despacito - Versión Pop"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:4V8Sr092TqfHkfAA5fXXqG",
+                "display": "Luis Fonsi"
+            }
+        ],
+        "genres": [
+            "latin",
+            "latin pop",
+            "puerto rican pop",
+            "tropical"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 2,
+        "energy": 74,
+        "danceability": 60
     },
     {
         "id": {
@@ -586,8 +1247,11 @@
                 "display": "Pentatonix"
             }
         ],
+        "genres": [
+            "a cappella"
+        ],
         "release_date": "2018-04-13",
-        "popularity": 56,
+        "popularity": 57,
         "energy": 63,
         "danceability": 69
     },
@@ -606,38 +1270,13 @@
                 "display": "Leroy Sanchez"
             }
         ],
+        "genres": [
+            "viral pop"
+        ],
         "release_date": "2017-05-25",
         "popularity": 59,
         "energy": 47,
         "danceability": 68
-    },
-    {
-        "id": {
-            "value": "spotify:track:3vqyauyYbp9MqUwrCEmWJ0",
-            "display": "Despacito"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:0fIdQWpwzU2oEtsoyArDOL",
-                "display": "Ramon Ayala"
-            },
-            {
-                "value": "spotify:artist:5HPu6u2rDA0f6jp51xZAEq",
-                "display": "Erika Ender"
-            },
-            {
-                "value": "spotify:artist:4ejKsCPdZGT8gDnsJs50rT",
-                "display": "Luis Rodr\u00edguez"
-            },
-            {
-                "value": "spotify:artist:6Fi8CHfO8WGtu3yO8c2Mc4",
-                "display": "2CELLOS"
-            }
-        ],
-        "release_date": "2017-07-19",
-        "popularity": 48,
-        "energy": 49,
-        "danceability": 64
     },
     {
         "id": {
@@ -649,6 +1288,11 @@
                 "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
                 "display": "Ariana Grande"
             }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2019-02-08",
         "popularity": 86,
@@ -670,26 +1314,16 @@
                 "display": "Derek DiScanio"
             }
         ],
+        "genres": [
+            "metalcore",
+            "pop punk",
+            "post-screamo",
+            "screamo"
+        ],
         "release_date": "2019-03-26",
         "popularity": 50,
         "energy": 92,
         "danceability": 59
-    },
-    {
-        "id": {
-            "value": "spotify:track:6va6SjWz457IOZidBppAhz",
-            "display": "7 rings - live"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
-                "display": "Ariana Grande"
-            }
-        ],
-        "release_date": "2019-12-23",
-        "popularity": 54,
-        "energy": 73,
-        "danceability": 44
     },
     {
         "id": {
@@ -701,6 +1335,9 @@
                 "value": "spotify:artist:1Vvvx45Apu6dQqwuZQxtgW",
                 "display": "Kidz Bop Kids"
             }
+        ],
+        "genres": [
+            "children's music"
         ],
         "release_date": "2019-11-15",
         "popularity": 44,
@@ -722,10 +1359,36 @@
                 "display": "2 Chainz"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2019-02-01",
         "popularity": 52,
         "energy": 34,
         "danceability": 78
+    },
+    {
+        "id": {
+            "value": "spotify:track:6va6SjWz457IOZidBppAhz",
+            "display": "7 rings - live"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
+                "display": "Ariana Grande"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2019-12-23",
+        "popularity": 53,
+        "energy": 73,
+        "danceability": 44
     },
     {
         "id": {
@@ -741,6 +1404,11 @@
                 "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
                 "display": "Justin Bieber"
             }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2020-05-08",
         "popularity": 93,
@@ -758,6 +1426,11 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2019-02-08",
         "popularity": 86,
         "energy": 31,
@@ -773,6 +1446,11 @@
                 "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
                 "display": "Ariana Grande"
             }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2019-02-08",
         "popularity": 84,
@@ -794,10 +1472,15 @@
                 "display": "Social House"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2019-08-02",
         "popularity": 81,
         "energy": 79,
-        "danceability": 4
+        "danceability": 40
     },
     {
         "id": {
@@ -809,6 +1492,11 @@
                 "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
                 "display": "Ariana Grande"
             }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2018-08-17",
         "popularity": 81,
@@ -826,6 +1514,11 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2019-02-08",
         "popularity": 80,
         "energy": 55,
@@ -842,8 +1535,13 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2018-08-17",
-        "popularity": 79,
+        "popularity": 80,
         "energy": 65,
         "danceability": 60
     },
@@ -857,6 +1555,11 @@
                 "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
                 "display": "Ariana Grande"
             }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2016-05-20",
         "popularity": 78,
@@ -874,8 +1577,13 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2014-08-25",
-        "popularity": 78,
+        "popularity": 79,
         "energy": 59,
         "danceability": 62
     },
@@ -894,26 +1602,15 @@
                 "display": "Nicki Minaj"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2016-05-20",
         "popularity": 77,
         "energy": 73,
         "danceability": 65
-    },
-    {
-        "id": {
-            "value": "spotify:track:4OafepJy2teCjYJbvFE60J",
-            "display": "breathin"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
-                "display": "Ariana Grande"
-            }
-        ],
-        "release_date": "2018-08-17",
-        "popularity": 76,
-        "energy": 65,
-        "danceability": 56
     },
     {
         "id": {
@@ -926,10 +1623,36 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2016-05-20",
         "popularity": 77,
         "energy": 60,
         "danceability": 66
+    },
+    {
+        "id": {
+            "value": "spotify:track:4OafepJy2teCjYJbvFE60J",
+            "display": "breathin"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
+                "display": "Ariana Grande"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2018-08-17",
+        "popularity": 76,
+        "energy": 65,
+        "danceability": 56
     },
     {
         "id": {
@@ -941,6 +1664,11 @@
                 "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
                 "display": "Ariana Grande"
             }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2019-02-08",
         "popularity": 73,
@@ -958,6 +1686,11 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2019-02-08",
         "popularity": 73,
         "energy": 45,
@@ -974,6 +1707,11 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2019-02-08",
         "popularity": 74,
         "energy": 47,
@@ -981,8 +1719,33 @@
     },
     {
         "id": {
+            "value": "spotify:track:7vS3Y0IKjde7Xg85LWIEdP",
+            "display": "Problem"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
+                "display": "Ariana Grande"
+            },
+            {
+                "value": "spotify:artist:5yG7ZAZafVaAlMTeBybKAL",
+                "display": "Iggy Azalea"
+            }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2014-08-25",
+        "popularity": 74,
+        "energy": 80,
+        "danceability": 66
+    },
+    {
+        "id": {
             "value": "spotify:track:6zegtH6XXd2PDPLvy1Y0n2",
-            "display": "Don\u2019t Call Me Angel (Charlie\u2019s Angels) (with Miley Cyrus & Lana Del Rey)"
+            "display": "Don’t Call Me Angel (Charlie’s Angels) (with Miley Cyrus & Lana Del Rey)"
         },
         "artists": [
             {
@@ -997,6 +1760,11 @@
                 "value": "spotify:artist:00FQb4jTyendYWaN8pK0wa",
                 "display": "Lana Del Rey"
             }
+        ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2019-11-01",
         "popularity": 76,
@@ -1018,30 +1786,15 @@
                 "display": "Mac Miller"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2013-01-01",
         "popularity": 67,
         "energy": 87,
         "danceability": 64
-    },
-    {
-        "id": {
-            "value": "spotify:track:7vS3Y0IKjde7Xg85LWIEdP",
-            "display": "Problem"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
-                "display": "Ariana Grande"
-            },
-            {
-                "value": "spotify:artist:5yG7ZAZafVaAlMTeBybKAL",
-                "display": "Iggy Azalea"
-            }
-        ],
-        "release_date": "2014-08-25",
-        "popularity": 74,
-        "energy": 80,
-        "danceability": 66
     },
     {
         "id": {
@@ -1054,9 +1807,14 @@
                 "display": "Ariana Grande"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2019-02-08",
         "popularity": 71,
-        "energy": 6,
+        "energy": 60,
         "danceability": 66
     },
     {
@@ -1074,8 +1832,13 @@
                 "display": "The Weeknd"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2014-08-25",
-        "popularity": 73,
+        "popularity": 74,
         "energy": 71,
         "danceability": 47
     },
@@ -1089,6 +1852,14 @@
                 "value": "spotify:artist:0PFtn5NtBbbUNbU9EAmIWF",
                 "display": "TOTO"
             }
+        ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
         ],
         "release_date": "1982-04-08",
         "popularity": 83,
@@ -1106,8 +1877,21 @@
                 "display": "Tom Petty"
             }
         ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "country rock",
+            "folk rock",
+            "heartland rock",
+            "mellow gold",
+            "pop rock",
+            "rock",
+            "roots rock",
+            "singer-songwriter",
+            "soft rock"
+        ],
         "release_date": "1989-01-01",
-        "popularity": 78,
+        "popularity": 79,
         "energy": 44,
         "danceability": 62
     },
@@ -1121,6 +1905,16 @@
                 "value": "spotify:artist:4bthk9UfsYUYdcFyqxmSUU",
                 "display": "Tears For Fears"
             }
+        ],
+        "genres": [
+            "dance rock",
+            "new romantic",
+            "new wave",
+            "new wave pop",
+            "permanent wave",
+            "rock",
+            "soft rock",
+            "synthpop"
         ],
         "release_date": "1985-02-25",
         "popularity": 81,
@@ -1138,42 +1932,15 @@
                 "display": "Whitney Houston"
             }
         ],
+        "genres": [
+            "dance pop",
+            "pop",
+            "urban contemporary"
+        ],
         "release_date": "1987-06-02",
-        "popularity": 81,
+        "popularity": 82,
         "energy": 82,
         "danceability": 70
-    },
-    {
-        "id": {
-            "value": "spotify:track:4bHsxqR3GMrXTxEPLuK5ue",
-            "display": "Don't Stop Believin'"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:0rvjqX7ttXeg3mTy8Xscbt",
-                "display": "Journey"
-            }
-        ],
-        "release_date": "1981",
-        "popularity": 80,
-        "energy": 74,
-        "danceability": 5
-    },
-    {
-        "id": {
-            "value": "spotify:track:37ZJ0p5Jm13JPevGcx4SkF",
-            "display": "Livin' On A Prayer"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:58lV9VcRSjABbAbfWS6skp",
-                "display": "Bon Jovi"
-            }
-        ],
-        "release_date": "1986-08-16",
-        "popularity": 82,
-        "energy": 88,
-        "danceability": 53
     },
     {
         "id": {
@@ -1186,10 +1953,60 @@
                 "display": "AC/DC"
             }
         ],
+        "genres": [
+            "album rock",
+            "australian rock",
+            "hard rock",
+            "rock"
+        ],
         "release_date": "1980-07-25",
-        "popularity": 82,
-        "energy": 7,
+        "popularity": 83,
+        "energy": 70,
         "danceability": 31
+    },
+    {
+        "id": {
+            "value": "spotify:track:4bHsxqR3GMrXTxEPLuK5ue",
+            "display": "Don't Stop Believin'"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:0rvjqX7ttXeg3mTy8Xscbt",
+                "display": "Journey"
+            }
+        ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "hard rock",
+            "mellow gold",
+            "rock",
+            "soft rock"
+        ],
+        "release_date": "1981",
+        "popularity": 80,
+        "energy": 74,
+        "danceability": 50
+    },
+    {
+        "id": {
+            "value": "spotify:track:37ZJ0p5Jm13JPevGcx4SkF",
+            "display": "Livin' On A Prayer"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:58lV9VcRSjABbAbfWS6skp",
+                "display": "Bon Jovi"
+            }
+        ],
+        "genres": [
+            "glam metal",
+            "rock"
+        ],
+        "release_date": "1986-08-16",
+        "popularity": 83,
+        "energy": 88,
+        "danceability": 53
     },
     {
         "id": {
@@ -1201,6 +2018,11 @@
                 "value": "spotify:artist:3qm84nBOXUEQ2vnTfUTTFC",
                 "display": "Guns N' Roses"
             }
+        ],
+        "genres": [
+            "glam metal",
+            "hard rock",
+            "rock"
         ],
         "release_date": "1987-07-21",
         "popularity": 74,
@@ -1218,6 +2040,18 @@
                 "display": "John Mellencamp"
             }
         ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "country rock",
+            "folk rock",
+            "heartland rock",
+            "mellow gold",
+            "pop rock",
+            "rock",
+            "singer-songwriter",
+            "soft rock"
+        ],
         "release_date": "1982",
         "popularity": 75,
         "energy": 41,
@@ -1233,6 +2067,14 @@
                 "value": "spotify:artist:77tT1kLj6mCWtFNqiOmP9H",
                 "display": "Daryl Hall & John Oates"
             }
+        ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
         ],
         "release_date": "1980",
         "popularity": 78,
@@ -1250,26 +2092,21 @@
                 "display": "Bryan Adams"
             }
         ],
+        "genres": [
+            "album rock",
+            "canadian pop",
+            "canadian singer-songwriter",
+            "classic canadian rock",
+            "heartland rock",
+            "mellow gold",
+            "pop rock",
+            "rock",
+            "soft rock"
+        ],
         "release_date": "1984-11-05",
         "popularity": 82,
         "energy": 83,
         "danceability": 50
-    },
-    {
-        "id": {
-            "value": "spotify:track:57JVGBtBLCfHw2muk5416J",
-            "display": "Another One Bites The Dust - Remastered 2011"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1dfeR4HaWDbWqFHLkxsg1d",
-                "display": "Queen"
-            }
-        ],
-        "release_date": "1980-06-27",
-        "popularity": 73,
-        "energy": 52,
-        "danceability": 93
     },
     {
         "id": {
@@ -1282,10 +2119,39 @@
                 "display": "a-ha"
             }
         ],
+        "genres": [
+            "dance rock",
+            "new romantic",
+            "new wave",
+            "new wave pop",
+            "permanent wave",
+            "soft rock",
+            "synthpop"
+        ],
         "release_date": "1985-06-01",
         "popularity": 83,
         "energy": 90,
         "danceability": 57
+    },
+    {
+        "id": {
+            "value": "spotify:track:57JVGBtBLCfHw2muk5416J",
+            "display": "Another One Bites The Dust - Remastered 2011"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:1dfeR4HaWDbWqFHLkxsg1d",
+                "display": "Queen"
+            }
+        ],
+        "genres": [
+            "glam rock",
+            "rock"
+        ],
+        "release_date": "1980-06-27",
+        "popularity": 73,
+        "energy": 52,
+        "danceability": 93
     },
     {
         "id": {
@@ -1298,8 +2164,13 @@
                 "display": "Michael Jackson"
             }
         ],
+        "genres": [
+            "pop",
+            "r&b",
+            "soul"
+        ],
         "release_date": "1982-11-30",
-        "popularity": 81,
+        "popularity": 82,
         "energy": 65,
         "danceability": 92
     },
@@ -1314,10 +2185,39 @@
                 "display": "Ozzy Osbourne"
             }
         ],
+        "genres": [
+            "album rock",
+            "birmingham metal",
+            "hard rock",
+            "metal",
+            "rock"
+        ],
         "release_date": "1980-09-20",
         "popularity": 77,
         "energy": 90,
         "danceability": 45
+    },
+    {
+        "id": {
+            "value": "spotify:track:2SiXAy7TuUkycRVbbWDEpo",
+            "display": "You Shook Me All Night Long"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:711MCceyCBcFnzjGY4Q7Un",
+                "display": "AC/DC"
+            }
+        ],
+        "genres": [
+            "album rock",
+            "australian rock",
+            "hard rock",
+            "rock"
+        ],
+        "release_date": "1980-07-25",
+        "popularity": 79,
+        "energy": 76,
+        "danceability": 53
     },
     {
         "id": {
@@ -1330,10 +2230,42 @@
                 "display": "Rick Springfield"
             }
         ],
+        "genres": [
+            "album rock",
+            "australian rock",
+            "classic rock",
+            "dance rock",
+            "heartland rock",
+            "mellow gold",
+            "new wave pop",
+            "soft rock",
+            "yacht rock"
+        ],
         "release_date": "1981",
         "popularity": 71,
         "energy": 83,
         "danceability": 72
+    },
+    {
+        "id": {
+            "value": "spotify:track:0G21yYKMZoHa30cYVi1iA8",
+            "display": "Welcome To The Jungle"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:3qm84nBOXUEQ2vnTfUTTFC",
+                "display": "Guns N' Roses"
+            }
+        ],
+        "genres": [
+            "glam metal",
+            "hard rock",
+            "rock"
+        ],
+        "release_date": "1987-07-21",
+        "popularity": 72,
+        "energy": 98,
+        "danceability": 45
     },
     {
         "id": {
@@ -1350,42 +2282,14 @@
                 "display": "David Bowie"
             }
         ],
+        "genres": [
+            "glam rock",
+            "rock"
+        ],
         "release_date": "1982-05-03",
         "popularity": 72,
         "energy": 71,
         "danceability": 67
-    },
-    {
-        "id": {
-            "value": "spotify:track:2SiXAy7TuUkycRVbbWDEpo",
-            "display": "You Shook Me All Night Long"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:711MCceyCBcFnzjGY4Q7Un",
-                "display": "AC/DC"
-            }
-        ],
-        "release_date": "1980-07-25",
-        "popularity": 79,
-        "energy": 76,
-        "danceability": 53
-    },
-    {
-        "id": {
-            "value": "spotify:track:0G21yYKMZoHa30cYVi1iA8",
-            "display": "Welcome To The Jungle"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:3qm84nBOXUEQ2vnTfUTTFC",
-                "display": "Guns N' Roses"
-            }
-        ],
-        "release_date": "1987-07-21",
-        "popularity": 72,
-        "energy": 98,
-        "danceability": 45
     },
     {
         "id": {
@@ -1397,6 +2301,16 @@
                 "value": "spotify:artist:6zFYqv1mOsgBRQbae3JJ9e",
                 "display": "Billy Joel"
             }
+        ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "folk rock",
+            "mellow gold",
+            "piano rock",
+            "rock",
+            "singer-songwriter",
+            "soft rock"
         ],
         "release_date": "1983-08-08",
         "popularity": 77,
@@ -1414,8 +2328,16 @@
                 "display": "Fleetwood Mac"
             }
         ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
+        ],
         "release_date": "1977-02-04",
-        "popularity": 80,
+        "popularity": 81,
         "energy": 49,
         "danceability": 82
     },
@@ -1429,6 +2351,16 @@
                 "value": "spotify:artist:4MVyzYMgTwdP7Z49wAZHx0",
                 "display": "Lynyrd Skynyrd"
             }
+        ],
+        "genres": [
+            "album rock",
+            "blues rock",
+            "classic rock",
+            "country rock",
+            "hard rock",
+            "mellow gold",
+            "rock",
+            "southern rock"
         ],
         "release_date": "1974-04-15",
         "popularity": 82,
@@ -1446,6 +2378,19 @@
                 "display": "Electric Light Orchestra"
             }
         ],
+        "genres": [
+            "album rock",
+            "art rock",
+            "beatlesque",
+            "bow pop",
+            "classic rock",
+            "folk rock",
+            "glam rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "symphonic rock"
+        ],
         "release_date": "1977",
         "popularity": 81,
         "energy": 33,
@@ -1461,6 +2406,12 @@
                 "value": "spotify:artist:3PhoLpVuITZKcymswpck5b",
                 "display": "Elton John"
             }
+        ],
+        "genres": [
+            "glam rock",
+            "mellow gold",
+            "piano rock",
+            "soft rock"
         ],
         "release_date": "1972-05-19",
         "popularity": 81,
@@ -1478,8 +2429,12 @@
                 "display": "Queen"
             }
         ],
+        "genres": [
+            "glam rock",
+            "rock"
+        ],
         "release_date": "1975-11-21",
-        "popularity": 74,
+        "popularity": 75,
         "energy": 40,
         "danceability": 39
     },
@@ -1494,42 +2449,21 @@
                 "display": "Eagles"
             }
         ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "country rock",
+            "folk rock",
+            "heartland rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
+        ],
         "release_date": "1976-12-08",
         "popularity": 82,
         "energy": 50,
         "danceability": 57
-    },
-    {
-        "id": {
-            "value": "spotify:track:7hQJA50XrCWABAu5v6QZ4i",
-            "display": "Don't Stop Me Now - 2011 Mix"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1dfeR4HaWDbWqFHLkxsg1d",
-                "display": "Queen"
-            }
-        ],
-        "release_date": "1978-11-10",
-        "popularity": 74,
-        "energy": 86,
-        "danceability": 56
-    },
-    {
-        "id": {
-            "value": "spotify:track:1bp2IO61zbQrbWNmKKxg3f",
-            "display": "The Joker"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:6QtGlUje9TIkLrgPZrESuk",
-                "display": "Steve Miller Band"
-            }
-        ],
-        "release_date": "1973-01-01",
-        "popularity": 77,
-        "energy": 44,
-        "danceability": 59
     },
     {
         "id": {
@@ -1542,9 +2476,69 @@
                 "display": "Elton John"
             }
         ],
+        "genres": [
+            "glam rock",
+            "mellow gold",
+            "piano rock",
+            "soft rock"
+        ],
         "release_date": "1971-11-05",
         "popularity": 79,
         "energy": 42,
+        "danceability": 41
+    },
+    {
+        "id": {
+            "value": "spotify:track:1bp2IO61zbQrbWNmKKxg3f",
+            "display": "The Joker"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:6QtGlUje9TIkLrgPZrESuk",
+                "display": "Steve Miller Band"
+            }
+        ],
+        "genres": [
+            "album rock",
+            "blues rock",
+            "classic rock",
+            "country rock",
+            "folk rock",
+            "hard rock",
+            "heartland rock",
+            "mellow gold",
+            "psychedelic rock",
+            "rock",
+            "roots rock",
+            "soft rock"
+        ],
+        "release_date": "1973-01-01",
+        "popularity": 77,
+        "energy": 44,
+        "danceability": 59
+    },
+    {
+        "id": {
+            "value": "spotify:track:5ihS6UUlyQAfmp48eSkxuQ",
+            "display": "Landslide"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:08GQAI4eElDnROBrJRGE0X",
+                "display": "Fleetwood Mac"
+            }
+        ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
+        ],
+        "release_date": "1975-07-11",
+        "popularity": 78,
+        "energy": 16,
         "danceability": 41
     },
     {
@@ -1558,6 +2552,14 @@
                 "display": "Fleetwood Mac"
             }
         ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
+        ],
         "release_date": "1977-02-04",
         "popularity": 79,
         "energy": 67,
@@ -1565,19 +2567,23 @@
     },
     {
         "id": {
-            "value": "spotify:track:5ihS6UUlyQAfmp48eSkxuQ",
-            "display": "Landslide"
+            "value": "spotify:track:7hQJA50XrCWABAu5v6QZ4i",
+            "display": "Don't Stop Me Now - 2011 Mix"
         },
         "artists": [
             {
-                "value": "spotify:artist:08GQAI4eElDnROBrJRGE0X",
-                "display": "Fleetwood Mac"
+                "value": "spotify:artist:1dfeR4HaWDbWqFHLkxsg1d",
+                "display": "Queen"
             }
         ],
-        "release_date": "1975-07-11",
-        "popularity": 77,
-        "energy": 16,
-        "danceability": 41
+        "genres": [
+            "glam rock",
+            "rock"
+        ],
+        "release_date": "1978-11-10",
+        "popularity": 74,
+        "energy": 86,
+        "danceability": 56
     },
     {
         "id": {
@@ -1589,6 +2595,19 @@
                 "value": "spotify:artist:4tX2TplrkIP4v05BNC903e",
                 "display": "Tom Petty and the Heartbreakers"
             }
+        ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "country rock",
+            "folk rock",
+            "hard rock",
+            "heartland rock",
+            "mellow gold",
+            "pop rock",
+            "rock",
+            "roots rock",
+            "soft rock"
         ],
         "release_date": "1976-11-09",
         "popularity": 75,
@@ -1606,6 +2625,17 @@
                 "display": "Eagles"
             }
         ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "country rock",
+            "folk rock",
+            "heartland rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
+        ],
         "release_date": "1972",
         "popularity": 77,
         "energy": 67,
@@ -1622,8 +2652,18 @@
                 "display": "Boston"
             }
         ],
+        "genres": [
+            "album rock",
+            "art rock",
+            "classic rock",
+            "country rock",
+            "hard rock",
+            "mellow gold",
+            "rock",
+            "soft rock"
+        ],
         "release_date": "1976",
-        "popularity": 78,
+        "popularity": 79,
         "energy": 68,
         "danceability": 37
     },
@@ -1637,6 +2677,14 @@
                 "value": "spotify:artist:08GQAI4eElDnROBrJRGE0X",
                 "display": "Fleetwood Mac"
             }
+        ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
         ],
         "release_date": "1977-02-04",
         "popularity": 74,
@@ -1654,8 +2702,14 @@
                 "display": "AC/DC"
             }
         ],
+        "genres": [
+            "album rock",
+            "australian rock",
+            "hard rock",
+            "rock"
+        ],
         "release_date": "1979-07-27",
-        "popularity": 82,
+        "popularity": 83,
         "energy": 91,
         "danceability": 57
     },
@@ -1670,8 +2724,12 @@
                 "display": "Looking Glass"
             }
         ],
+        "genres": [
+            "soft rock",
+            "sunshine pop"
+        ],
         "release_date": "1972",
-        "popularity": 74,
+        "popularity": 75,
         "energy": 62,
         "danceability": 71
     },
@@ -1685,6 +2743,20 @@
                 "value": "spotify:artist:39T6qqI0jDtSWWioX8eGJz",
                 "display": "The Doobie Brothers"
             }
+        ],
+        "genres": [
+            "album rock",
+            "art rock",
+            "blues rock",
+            "classic rock",
+            "country rock",
+            "folk rock",
+            "hard rock",
+            "heartland rock",
+            "mellow gold",
+            "rock",
+            "soft rock",
+            "yacht rock"
         ],
         "release_date": "1972",
         "popularity": 76,
@@ -1702,6 +2774,15 @@
                 "display": "Creedence Clearwater Revival"
             }
         ],
+        "genres": [
+            "album rock",
+            "classic rock",
+            "country rock",
+            "rock",
+            "roots rock",
+            "southern rock",
+            "swamp rock"
+        ],
         "release_date": "1970-12-07",
         "popularity": 72,
         "energy": 47,
@@ -1715,11 +2796,21 @@
         "artists": [
             {
                 "value": "spotify:artist:00tVTdpEhQQw1bqdu8RCx2",
-                "display": "Blue \u00d6yster Cult"
+                "display": "Blue Öyster Cult"
             }
         ],
+        "genres": [
+            "album rock",
+            "art rock",
+            "blues rock",
+            "classic rock",
+            "hard rock",
+            "metal",
+            "rock",
+            "soft rock"
+        ],
         "release_date": "1976",
-        "popularity": 75,
+        "popularity": 76,
         "energy": 92,
         "danceability": 33
     },
@@ -1738,8 +2829,13 @@
                 "display": "Quavo"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2020-02-07",
-        "popularity": 88,
+        "popularity": 87,
         "energy": 55,
         "danceability": 81
     },
@@ -1757,6 +2853,11 @@
                 "value": "spotify:artist:0VRj0yCOv2FXJNP47XQnx5",
                 "display": "Quavo"
             }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2020-02-14",
         "popularity": 87,
@@ -1782,6 +2883,11 @@
                 "display": "Clever"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2020-02-14",
         "popularity": 78,
         "energy": 48,
@@ -1797,6 +2903,11 @@
                 "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
                 "display": "Justin Bieber"
             }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2020-01-03",
         "popularity": 82,
@@ -1814,6 +2925,11 @@
                 "display": "Justin Bieber"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2015-11-13",
         "popularity": 81,
         "energy": 37,
@@ -1829,6 +2945,11 @@
                 "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
                 "display": "Justin Bieber"
             }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2015-11-13",
         "popularity": 80,
@@ -1850,6 +2971,11 @@
                 "display": "Ludacris"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2010-01-01",
         "popularity": 75,
         "energy": 85,
@@ -1865,6 +2991,11 @@
                 "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
                 "display": "Justin Bieber"
             }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2015-11-13",
         "popularity": 77,
@@ -1882,6 +3013,11 @@
                 "display": "Justin Bieber"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2020-02-14",
         "popularity": 78,
         "energy": 50,
@@ -1898,10 +3034,40 @@
                 "display": "Justin Bieber"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2020-02-14",
-        "popularity": 74,
+        "popularity": 73,
         "energy": 68,
         "danceability": 64
+    },
+    {
+        "id": {
+            "value": "spotify:track:190jyVPHYjAqEaOGmMzdyk",
+            "display": "Beauty And A Beat"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
+                "display": "Justin Bieber"
+            },
+            {
+                "value": "spotify:artist:0hCNtLu0JehylgoiP8L4Gh",
+                "display": "Nicki Minaj"
+            }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2012-06-15",
+        "popularity": 70,
+        "energy": 84,
+        "danceability": 60
     },
     {
         "id": {
@@ -1917,6 +3083,11 @@
                 "value": "spotify:artist:0cGUm45nv7Z6M6qdXYQGTX",
                 "display": "Kehlani"
             }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
         ],
         "release_date": "2020-02-14",
         "popularity": 69,
@@ -1934,30 +3105,36 @@
                 "display": "Justin Bieber"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2020-02-14",
-        "popularity": 71,
+        "popularity": 70,
         "energy": 44,
         "danceability": 76
     },
     {
         "id": {
-            "value": "spotify:track:190jyVPHYjAqEaOGmMzdyk",
-            "display": "Beauty And A Beat"
+            "value": "spotify:track:2IjyFRCRn8x1bEquOM3vxg",
+            "display": "Purpose"
         },
         "artists": [
             {
                 "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
                 "display": "Justin Bieber"
-            },
-            {
-                "value": "spotify:artist:0hCNtLu0JehylgoiP8L4Gh",
-                "display": "Nicki Minaj"
             }
         ],
-        "release_date": "2012-06-15",
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2015-11-13",
         "popularity": 70,
-        "energy": 84,
-        "danceability": 60
+        "energy": 28,
+        "danceability": 48
     },
     {
         "id": {
@@ -1970,10 +3147,99 @@
                 "display": "Justin Bieber"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2020-02-14",
-        "popularity": 70,
+        "popularity": 69,
         "energy": 43,
         "danceability": 56
+    },
+    {
+        "id": {
+            "value": "spotify:track:3UGIZ8qcrMTwzLbx6Kttqt",
+            "display": "Boyfriend"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
+                "display": "Justin Bieber"
+            }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2012-01-01",
+        "popularity": 68,
+        "energy": 55,
+        "danceability": 71
+    },
+    {
+        "id": {
+            "value": "spotify:track:6eDApnV9Jdb1nYahOlbbUh",
+            "display": "One Time"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
+                "display": "Justin Bieber"
+            }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2009-01-01",
+        "popularity": 68,
+        "energy": 85,
+        "danceability": 69
+    },
+    {
+        "id": {
+            "value": "spotify:track:0aPZbnkMoWJaJ5CNVLCj8S",
+            "display": "That Should Be Me"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
+                "display": "Justin Bieber"
+            }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2010-01-01",
+        "popularity": 67,
+        "energy": 60,
+        "danceability": 55
+    },
+    {
+        "id": {
+            "value": "spotify:track:3rLIv187BhjyweFe89SgLn",
+            "display": "Somebody To Love"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
+                "display": "Justin Bieber"
+            }
+        ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
+        "release_date": "2010-01-01",
+        "popularity": 66,
+        "energy": 83,
+        "danceability": 71
     },
     {
         "id": {
@@ -1990,94 +3256,15 @@
                 "display": "Lil Dicky"
             }
         ],
+        "genres": [
+            "canadian pop",
+            "pop",
+            "post-teen pop"
+        ],
         "release_date": "2020-02-14",
         "popularity": 67,
         "energy": 60,
         "danceability": 77
-    },
-    {
-        "id": {
-            "value": "spotify:track:1b6tPXXCV2fSNtR3SKWUQA",
-            "display": "Available"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
-                "display": "Justin Bieber"
-            }
-        ],
-        "release_date": "2020-02-14",
-        "popularity": 68,
-        "energy": 60,
-        "danceability": 70
-    },
-    {
-        "id": {
-            "value": "spotify:track:6eDApnV9Jdb1nYahOlbbUh",
-            "display": "One Time"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
-                "display": "Justin Bieber"
-            }
-        ],
-        "release_date": "2009-01-01",
-        "popularity": 67,
-        "energy": 85,
-        "danceability": 69
-    },
-    {
-        "id": {
-            "value": "spotify:track:2IjyFRCRn8x1bEquOM3vxg",
-            "display": "Purpose"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
-                "display": "Justin Bieber"
-            }
-        ],
-        "release_date": "2015-11-13",
-        "popularity": 69,
-        "energy": 28,
-        "danceability": 48
-    },
-    {
-        "id": {
-            "value": "spotify:track:0aPZbnkMoWJaJ5CNVLCj8S",
-            "display": "That Should Be Me"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
-                "display": "Justin Bieber"
-            }
-        ],
-        "release_date": "2010-01-01",
-        "popularity": 67,
-        "energy": 60,
-        "danceability": 55
-    },
-    {
-        "id": {
-            "value": "spotify:track:7iNIg7XDEaYECfWD5dJ9Va",
-            "display": "Friends (with BloodPop\u00ae)"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
-                "display": "Justin Bieber"
-            },
-            {
-                "value": "spotify:artist:1okJ4NC308qbtY9LyHn6DO",
-                "display": "BloodPop\u00ae"
-            }
-        ],
-        "release_date": "2017-08-17",
-        "popularity": 72,
-        "energy": 73,
-        "danceability": 74
     },
     {
         "id": {
@@ -2090,10 +3277,34 @@
                 "display": "Maroon 5"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2019-09-20",
         "popularity": 90,
         "energy": 32,
         "danceability": 76
+    },
+    {
+        "id": {
+            "value": "spotify:track:3kwgqoBqTwoAH4nT29TYrq",
+            "display": "Nobody's Love"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
+                "display": "Maroon 5"
+            }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
+        "release_date": "2020-07-24",
+        "popularity": 78,
+        "energy": 56,
+        "danceability": 48
     },
     {
         "id": {
@@ -2105,6 +3316,10 @@
                 "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
                 "display": "Maroon 5"
             }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
         ],
         "release_date": "2014-09-02",
         "popularity": 79,
@@ -2126,8 +3341,12 @@
                 "display": "Wiz Khalifa"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2012-01-01",
-        "popularity": 72,
+        "popularity": 73,
         "energy": 75,
         "danceability": 73
     },
@@ -2141,6 +3360,10 @@
                 "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
                 "display": "Maroon 5"
             }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
         ],
         "release_date": "2002",
         "popularity": 80,
@@ -2162,6 +3385,10 @@
                 "display": "Cardi B"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2018-06-15",
         "popularity": 71,
         "energy": 54,
@@ -2177,6 +3404,10 @@
                 "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
                 "display": "Maroon 5"
             }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
         ],
         "release_date": "2014-09-02",
         "popularity": 76,
@@ -2198,6 +3429,10 @@
                 "display": "Christina Aguilera"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2010",
         "popularity": 70,
         "energy": 75,
@@ -2218,6 +3453,10 @@
                 "display": "SZA"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2018-06-15",
         "popularity": 68,
         "energy": 59,
@@ -2234,6 +3473,10 @@
                 "display": "Maroon 5"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2002",
         "popularity": 77,
         "energy": 86,
@@ -2249,6 +3492,10 @@
                 "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
                 "display": "Maroon 5"
             }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
         ],
         "release_date": "2014-09-02",
         "popularity": 75,
@@ -2270,8 +3517,12 @@
                 "display": "Cardi B"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2018-05-30",
-        "popularity": 78,
+        "popularity": 77,
         "energy": 54,
         "danceability": 85
     },
@@ -2286,8 +3537,12 @@
                 "display": "Maroon 5"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2002-06-25",
-        "popularity": 72,
+        "popularity": 73,
         "energy": 71,
         "danceability": 70
     },
@@ -2301,6 +3556,10 @@
                 "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
                 "display": "Maroon 5"
             }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
         ],
         "release_date": "2012-01-01",
         "popularity": 66,
@@ -2318,8 +3577,12 @@
                 "display": "Maroon 5"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2002",
-        "popularity": 70,
+        "popularity": 71,
         "energy": 76,
         "danceability": 60
     },
@@ -2338,6 +3601,10 @@
                 "display": "Kendrick Lamar"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2018-06-15",
         "popularity": 64,
         "energy": 61,
@@ -2353,6 +3620,10 @@
                 "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
                 "display": "Maroon 5"
             }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
         ],
         "release_date": "2018-06-15",
         "popularity": 64,
@@ -2370,6 +3641,10 @@
                 "display": "Maroon 5"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2010",
         "popularity": 62,
         "energy": 81,
@@ -2385,6 +3660,10 @@
                 "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
                 "display": "Maroon 5"
             }
+        ],
+        "genres": [
+            "pop",
+            "pop rock"
         ],
         "release_date": "2018-06-15",
         "popularity": 63,
@@ -2406,26 +3685,14 @@
                 "display": "Future"
             }
         ],
+        "genres": [
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2018-06-15",
         "popularity": 63,
         "energy": 71,
         "danceability": 69
-    },
-    {
-        "id": {
-            "value": "spotify:track:1YI0uK36eupTmw9F8kHysr",
-            "display": "Sunday Morning"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:04gDigrS5kc9YWfZHwBETP",
-                "display": "Maroon 5"
-            }
-        ],
-        "release_date": "2002-06-25",
-        "popularity": 67,
-        "energy": 76,
-        "danceability": 60
     },
     {
         "id": {
@@ -2437,6 +3704,12 @@
                 "value": "spotify:artist:0C0XlULifJtAgn6ZNCW2eu",
                 "display": "The Killers"
             }
+        ],
+        "genres": [
+            "modern rock",
+            "permanent wave",
+            "pop rock",
+            "rock"
         ],
         "release_date": "2004-06-15",
         "popularity": 78,
@@ -2458,6 +3731,11 @@
                 "display": "Nate Dogg"
             }
         ],
+        "genres": [
+            "detroit hip hop",
+            "hip hop",
+            "rap"
+        ],
         "release_date": "2002-05-26",
         "popularity": 83,
         "energy": 84,
@@ -2473,6 +3751,12 @@
                 "value": "spotify:artist:20JZFwl6HVl6yg8a4H3ZqK",
                 "display": "Panic! At The Disco"
             }
+        ],
+        "genres": [
+            "baroque pop",
+            "emo",
+            "modern rock",
+            "pop punk"
         ],
         "release_date": "2005-09-27",
         "popularity": 74,
@@ -2490,8 +3774,14 @@
                 "display": "Plain White T's"
             }
         ],
+        "genres": [
+            "neo mellow",
+            "pop",
+            "pop punk",
+            "pop rock"
+        ],
         "release_date": "2005-01-01",
-        "popularity": 79,
+        "popularity": 80,
         "energy": 29,
         "danceability": 65
     },
@@ -2505,6 +3795,11 @@
                 "value": "spotify:artist:4UXqAaa6dQYAk18Lv7PEgX",
                 "display": "Fall Out Boy"
             }
+        ],
+        "genres": [
+            "emo",
+            "modern rock",
+            "pop punk"
         ],
         "release_date": "2005-05-03",
         "popularity": 77,
@@ -2530,8 +3825,16 @@
                 "display": "Ludacris"
             }
         ],
+        "genres": [
+            "atl hip hop",
+            "dance pop",
+            "pop",
+            "r&b",
+            "south carolina hip hop",
+            "urban contemporary"
+        ],
         "release_date": "2004-03-23",
-        "popularity": 80,
+        "popularity": 81,
         "energy": 79,
         "danceability": 89
     },
@@ -2545,6 +3848,16 @@
                 "value": "spotify:artist:3jOstUTkEu2JkjvRdBA5Gu",
                 "display": "Weezer"
             }
+        ],
+        "genres": [
+            "alternative rock",
+            "modern power pop",
+            "modern rock",
+            "permanent wave",
+            "pop punk",
+            "pop rock",
+            "post-grunge",
+            "rock"
         ],
         "release_date": "2001-05-15",
         "popularity": 77,
@@ -2566,8 +3879,15 @@
                 "display": "Wyclef Jean"
             }
         ],
+        "genres": [
+            "colombian pop",
+            "dance pop",
+            "latin",
+            "latin pop",
+            "pop"
+        ],
         "release_date": "2005-11-28",
-        "popularity": 82,
+        "popularity": 83,
         "energy": 82,
         "danceability": 77
     },
@@ -2582,8 +3902,12 @@
                 "display": "Gorillaz"
             }
         ],
+        "genres": [
+            "alternative hip hop",
+            "art pop"
+        ],
         "release_date": "2005-05-23",
-        "popularity": 80,
+        "popularity": 81,
         "energy": 70,
         "danceability": 81
     },
@@ -2598,26 +3922,20 @@
                 "display": "Jimmy Eat World"
             }
         ],
+        "genres": [
+            "emo",
+            "modern power pop",
+            "modern rock",
+            "neo mellow",
+            "pop punk",
+            "pop rock",
+            "post-grunge",
+            "rock"
+        ],
         "release_date": "2001-07-17",
         "popularity": 77,
         "energy": 84,
         "danceability": 64
-    },
-    {
-        "id": {
-            "value": "spotify:track:0I3q5fE6wg7LIfHGngUTnV",
-            "display": "Ms. Jackson"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1G9G7WwrXka3Z1r7aIDjI7",
-                "display": "OutKast"
-            }
-        ],
-        "release_date": "2000-10-31",
-        "popularity": 79,
-        "energy": 80,
-        "danceability": 84
     },
     {
         "id": {
@@ -2629,6 +3947,11 @@
                 "value": "spotify:artist:3FUY2gzHeIiaesXtOAdB7A",
                 "display": "Train"
             }
+        ],
+        "genres": [
+            "neo mellow",
+            "pop",
+            "pop rock"
         ],
         "release_date": "2001-03-27",
         "popularity": 78,
@@ -2650,26 +3973,14 @@
                 "display": "Jamie Foxx"
             }
         ],
+        "genres": [
+            "chicago rap",
+            "rap"
+        ],
         "release_date": "2005-09-30",
         "popularity": 77,
         "energy": 69,
-        "danceability": 63
-    },
-    {
-        "id": {
-            "value": "spotify:track:7lQ8MOhq6IN2w8EYcFNSUk",
-            "display": "Without Me"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:7dGJo4pcD2V6oG8kP0tJRR",
-                "display": "Eminem"
-            }
-        ],
-        "release_date": "2002-05-26",
-        "popularity": 82,
-        "energy": 66,
-        "danceability": 90
+        "danceability": 62
     },
     {
         "id": {
@@ -2682,6 +3993,13 @@
                 "display": "The Fray"
             }
         ],
+        "genres": [
+            "modern rock",
+            "neo mellow",
+            "piano rock",
+            "pop",
+            "pop rock"
+        ],
         "release_date": "2005-09-13",
         "popularity": 80,
         "energy": 74,
@@ -2689,19 +4007,24 @@
     },
     {
         "id": {
-            "value": "spotify:track:7i6r9KotUPQg3ozKKgEPIN",
-            "display": "Seven Nation Army"
+            "value": "spotify:track:7lQ8MOhq6IN2w8EYcFNSUk",
+            "display": "Without Me"
         },
         "artists": [
             {
-                "value": "spotify:artist:4F84IBURUo98rz4r61KF70",
-                "display": "The White Stripes"
+                "value": "spotify:artist:7dGJo4pcD2V6oG8kP0tJRR",
+                "display": "Eminem"
             }
         ],
-        "release_date": "2003-04-01",
-        "popularity": 73,
-        "energy": 46,
-        "danceability": 73
+        "genres": [
+            "detroit hip hop",
+            "hip hop",
+            "rap"
+        ],
+        "release_date": "2002-05-26",
+        "popularity": 82,
+        "energy": 66,
+        "danceability": 90
     },
     {
         "id": {
@@ -2713,6 +4036,12 @@
                 "value": "spotify:artist:6XyY86QOPPrYVGvF9ch6wz",
                 "display": "Linkin Park"
             }
+        ],
+        "genres": [
+            "alternative metal",
+            "nu metal",
+            "post-grunge",
+            "rap metal"
         ],
         "release_date": "2000-10-24",
         "popularity": 83,
@@ -2730,10 +4059,45 @@
                 "display": "Carrie Underwood"
             }
         ],
+        "genres": [
+            "contemporary country",
+            "country",
+            "country dawn",
+            "country road",
+            "dance pop",
+            "oklahoma country",
+            "pop"
+        ],
         "release_date": "2005-11-14",
         "popularity": 74,
         "energy": 74,
         "danceability": 51
+    },
+    {
+        "id": {
+            "value": "spotify:track:7i6r9KotUPQg3ozKKgEPIN",
+            "display": "Seven Nation Army"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:4F84IBURUo98rz4r61KF70",
+                "display": "The White Stripes"
+            }
+        ],
+        "genres": [
+            "alternative rock",
+            "blues rock",
+            "garage rock",
+            "modern blues rock",
+            "modern rock",
+            "permanent wave",
+            "punk blues",
+            "rock"
+        ],
+        "release_date": "2003-04-01",
+        "popularity": 73,
+        "energy": 46,
+        "danceability": 73
     },
     {
         "id": {
@@ -2746,6 +4110,12 @@
                 "display": "3 Doors Down"
             }
         ],
+        "genres": [
+            "alternative metal",
+            "nu metal",
+            "pop rock",
+            "post-grunge"
+        ],
         "release_date": "2000",
         "popularity": 77,
         "energy": 86,
@@ -2753,19 +4123,50 @@
     },
     {
         "id": {
-            "value": "spotify:track:5Z01UMMf7V1o0MzF86s6WJ",
-            "display": "Lose Yourself - From \"8 Mile\" Soundtrack"
+            "value": "spotify:track:2PpruBYCo4H7WOBJ7Q2EwM",
+            "display": "Hey Ya! - Radio Mix"
         },
         "artists": [
             {
-                "value": "spotify:artist:7dGJo4pcD2V6oG8kP0tJRR",
-                "display": "Eminem"
+                "value": "spotify:artist:1G9G7WwrXka3Z1r7aIDjI7",
+                "display": "OutKast"
             }
         ],
-        "release_date": "2005-12-06",
-        "popularity": 76,
-        "energy": 74,
-        "danceability": 69
+        "genres": [
+            "atl hip hop",
+            "dirty south rap",
+            "hip hop",
+            "rap",
+            "southern hip hop"
+        ],
+        "release_date": "2003",
+        "popularity": 79,
+        "energy": 97,
+        "danceability": 72
+    },
+    {
+        "id": {
+            "value": "spotify:track:5W8YXBz9MTIDyrpYaCg2Ky",
+            "display": "Last Resort"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:4RddZ3iHvSpGV4dvATac9X",
+                "display": "Papa Roach"
+            }
+        ],
+        "genres": [
+            "alternative metal",
+            "nu metal",
+            "pop punk",
+            "post-grunge",
+            "rap metal",
+            "rap rock"
+        ],
+        "release_date": "2001-04-25",
+        "popularity": 79,
+        "energy": 89,
+        "danceability": 58
     },
     {
         "id": {
@@ -2782,26 +4183,14 @@
                 "display": "Roddy Ricch"
             }
         ],
+        "genres": [
+            "north carolina hip hop",
+            "rap"
+        ],
         "release_date": "2020-04-17",
         "popularity": 100,
         "energy": 69,
         "danceability": 74
-    },
-    {
-        "id": {
-            "value": "spotify:track:5RqR4ZCCKJDcBLIn4sih9l",
-            "display": "Party Girl"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1XLWox9w1Yvbodui0SRhUQ",
-                "display": "StaySolidRocky"
-            }
-        ],
-        "release_date": "2020-04-21",
-        "popularity": 94,
-        "energy": 43,
-        "danceability": 72
     },
     {
         "id": {
@@ -2814,66 +4203,15 @@
                 "display": "The Weeknd"
             }
         ],
+        "genres": [
+            "canadian contemporary r&b",
+            "canadian pop",
+            "pop"
+        ],
         "release_date": "2020-03-20",
         "popularity": 99,
         "energy": 73,
         "danceability": 51
-    },
-    {
-        "id": {
-            "value": "spotify:track:39Yp9wwQiSRIDOvrVg7mbk",
-            "display": "THE SCOTTS"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:2PaZWGu5T5nHjY2xxAkFsT",
-                "display": "THE SCOTTS"
-            },
-            {
-                "value": "spotify:artist:0Y5tJX1MQlPlqiwlOH1tJY",
-                "display": "Travis Scott"
-            },
-            {
-                "value": "spotify:artist:0fA0VVWsXO9YnASrzqfmYu",
-                "display": "Kid Cudi"
-            }
-        ],
-        "release_date": "2020-04-24",
-        "popularity": 93,
-        "energy": 53,
-        "danceability": 71
-    },
-    {
-        "id": {
-            "value": "spotify:track:6wJYhPfqk3KGhHRG76WzOh",
-            "display": "Blueberry Faygo"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:5zctI4wO9XSKS8XwcnqEHk",
-                "display": "Lil Mosey"
-            }
-        ],
-        "release_date": "2020-02-07",
-        "popularity": 90,
-        "energy": 55,
-        "danceability": 77
-    },
-    {
-        "id": {
-            "value": "spotify:track:1jaTQ3nqY3oAAYyCTbIvnM",
-            "display": "WHATS POPPIN"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:2LIk90788K0zvyj2JJVwkJ",
-                "display": "Jack Harlow"
-            }
-        ],
-        "release_date": "2020-03-13",
-        "popularity": 90,
-        "energy": 60,
-        "danceability": 92
     },
     {
         "id": {
@@ -2898,15 +4236,160 @@
                 "display": "Lil Wayne"
             }
         ],
+        "genres": [
+            "deep underground hip hop",
+            "kentucky hip hop",
+            "pop rap",
+            "rap",
+            "trap"
+        ],
         "release_date": "2020-06-24",
-        "popularity": 89,
+        "popularity": 92,
         "energy": 72,
         "danceability": 90
     },
     {
         "id": {
+            "value": "spotify:track:5RqR4ZCCKJDcBLIn4sih9l",
+            "display": "Party Girl"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:1XLWox9w1Yvbodui0SRhUQ",
+                "display": "StaySolidRocky"
+            }
+        ],
+        "genres": [],
+        "release_date": "2020-04-21",
+        "popularity": 94,
+        "energy": 43,
+        "danceability": 72
+    },
+    {
+        "id": {
+            "value": "spotify:track:39Yp9wwQiSRIDOvrVg7mbk",
+            "display": "THE SCOTTS"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:2PaZWGu5T5nHjY2xxAkFsT",
+                "display": "THE SCOTTS"
+            },
+            {
+                "value": "spotify:artist:0Y5tJX1MQlPlqiwlOH1tJY",
+                "display": "Travis Scott"
+            },
+            {
+                "value": "spotify:artist:0fA0VVWsXO9YnASrzqfmYu",
+                "display": "Kid Cudi"
+            }
+        ],
+        "genres": [],
+        "release_date": "2020-04-24",
+        "popularity": 92,
+        "energy": 53,
+        "danceability": 71
+    },
+    {
+        "id": {
+            "value": "spotify:track:6wJYhPfqk3KGhHRG76WzOh",
+            "display": "Blueberry Faygo"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:5zctI4wO9XSKS8XwcnqEHk",
+                "display": "Lil Mosey"
+            }
+        ],
+        "genres": [
+            "melodic rap",
+            "rap conscient",
+            "vapor trap"
+        ],
+        "release_date": "2020-02-07",
+        "popularity": 90,
+        "energy": 55,
+        "danceability": 77
+    },
+    {
+        "id": {
+            "value": "spotify:track:6gxKUmycQX7uyMwJcweFjp",
+            "display": "We Paid (feat. 42 Dugg)"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:5f7VJjfbwm532GiveGC0ZK",
+                "display": "Lil Baby"
+            },
+            {
+                "value": "spotify:artist:45gHcnDnMC15sgx3VL7ROG",
+                "display": "42 Dugg"
+            }
+        ],
+        "genres": [
+            "atl hip hop",
+            "atl trap",
+            "rap"
+        ],
+        "release_date": "2020-05-01",
+        "popularity": 87,
+        "energy": 54,
+        "danceability": 92
+    },
+    {
+        "id": {
+            "value": "spotify:track:1jaTQ3nqY3oAAYyCTbIvnM",
+            "display": "WHATS POPPIN"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:2LIk90788K0zvyj2JJVwkJ",
+                "display": "Jack Harlow"
+            }
+        ],
+        "genres": [
+            "deep underground hip hop",
+            "kentucky hip hop",
+            "pop rap",
+            "rap",
+            "trap"
+        ],
+        "release_date": "2020-03-13",
+        "popularity": 89,
+        "energy": 60,
+        "danceability": 92
+    },
+    {
+        "id": {
+            "value": "spotify:track:0PvFJmanyNQMseIFrU708S",
+            "display": "For The Night (feat. Lil Baby & DaBaby)"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:0eDvMgVFoNV3TpwtrVCoTj",
+                "display": "Pop Smoke"
+            },
+            {
+                "value": "spotify:artist:5f7VJjfbwm532GiveGC0ZK",
+                "display": "Lil Baby"
+            },
+            {
+                "value": "spotify:artist:4r63FhuTkUYltbVAg5TQnk",
+                "display": "DaBaby"
+            }
+        ],
+        "genres": [
+            "brooklyn drill"
+        ],
+        "release_date": "2020-07-03",
+        "popularity": 89,
+        "energy": 58,
+        "danceability": 82
+    },
+    {
+        "id": {
             "value": "spotify:track:5v4GgrXPMghOnBBLmveLac",
-            "display": "Savage Remix (feat. Beyonc\u00e9)"
+            "display": "Savage Remix (feat. Beyoncé)"
         },
         "artists": [
             {
@@ -2915,11 +4398,17 @@
             },
             {
                 "value": "spotify:artist:6vWDO969PvNqNYHIOW5v0m",
-                "display": "Beyonc\u00e9"
+                "display": "Beyoncé"
             }
         ],
+        "genres": [
+            "houston rap",
+            "pop",
+            "pop rap",
+            "trap queen"
+        ],
         "release_date": "2020-04-29",
-        "popularity": 91,
+        "popularity": 90,
         "energy": 74,
         "danceability": 82
     },
@@ -2933,6 +4422,10 @@
                 "value": "spotify:artist:4Gso3d4CscCijv0lmajZWs",
                 "display": "Don Toliver"
             }
+        ],
+        "genres": [
+            "rap",
+            "trap"
         ],
         "release_date": "2020-03-13",
         "popularity": 89,
@@ -2954,10 +4447,34 @@
                 "display": "beabadoobee"
             }
         ],
+        "genres": [],
         "release_date": "2020-02-08",
-        "popularity": 96,
+        "popularity": 95,
         "energy": 43,
         "danceability": 72
+    },
+    {
+        "id": {
+            "value": "spotify:track:1ENdcyhqdylaLsPVgB83qq",
+            "display": "Rags2Riches (feat. ATR Son Son)"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:45TgXXqMDdF8BkjA83OM7z",
+                "display": "Rod Wave"
+            },
+            {
+                "value": "spotify:artist:1nGRqM8VNcQOcFsOnhpInD",
+                "display": "ATR Son Son"
+            }
+        ],
+        "genres": [
+            "florida rap"
+        ],
+        "release_date": "2020-04-03",
+        "popularity": 86,
+        "energy": 25,
+        "danceability": 90
     },
     {
         "id": {
@@ -2974,46 +4491,40 @@
                 "display": "Roddy Ricch"
             }
         ],
+        "genres": [
+            "memphis hip hop"
+        ],
         "release_date": "2020-03-19",
-        "popularity": 88,
+        "popularity": 87,
         "energy": 74,
         "danceability": 86
     },
     {
         "id": {
-            "value": "spotify:track:6gxKUmycQX7uyMwJcweFjp",
-            "display": "We Paid (feat. 42 Dugg)"
+            "value": "spotify:track:1H7KnK26kc1YyellpbINEn",
+            "display": "The Woo (feat. 50 Cent & Roddy Ricch)"
         },
         "artists": [
             {
-                "value": "spotify:artist:5f7VJjfbwm532GiveGC0ZK",
-                "display": "Lil Baby"
+                "value": "spotify:artist:0eDvMgVFoNV3TpwtrVCoTj",
+                "display": "Pop Smoke"
             },
             {
-                "value": "spotify:artist:45gHcnDnMC15sgx3VL7ROG",
-                "display": "42 Dugg"
-            }
-        ],
-        "release_date": "2020-05-01",
-        "popularity": 86,
-        "energy": 54,
-        "danceability": 92
-    },
-    {
-        "id": {
-            "value": "spotify:track:127QTOFJsJQp5LbJbu3A1y",
-            "display": "Toosie Slide"
-        },
-        "artists": [
+                "value": "spotify:artist:3q7HBObVc0L8jNeTe5Gofh",
+                "display": "50 Cent"
+            },
             {
-                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
-                "display": "Drake"
+                "value": "spotify:artist:757aE44tKEUQEqRuT6GnEB",
+                "display": "Roddy Ricch"
             }
         ],
-        "release_date": "2020-04-03",
-        "popularity": 93,
-        "energy": 45,
-        "danceability": 83
+        "genres": [
+            "brooklyn drill"
+        ],
+        "release_date": "2020-07-03",
+        "popularity": 90,
+        "energy": 61,
+        "danceability": 49
     },
     {
         "id": {
@@ -3025,6 +4536,11 @@
                 "value": "spotify:artist:5f7VJjfbwm532GiveGC0ZK",
                 "display": "Lil Baby"
             }
+        ],
+        "genres": [
+            "atl hip hop",
+            "atl trap",
+            "rap"
         ],
         "release_date": "2020-06-12",
         "popularity": 86,
@@ -3046,6 +4562,14 @@
                 "display": "Giveon"
             }
         ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
         "release_date": "2020-05-01",
         "popularity": 88,
         "energy": 44,
@@ -3066,70 +4590,13 @@
                 "display": "Juice WRLD"
             }
         ],
+        "genres": [
+            "chicago rap"
+        ],
         "release_date": "2020-05-15",
         "popularity": 86,
         "energy": 67,
         "danceability": 75
-    },
-    {
-        "id": {
-            "value": "spotify:track:24ySl2hOPGCDcxBxFIqWBu",
-            "display": "Rain On Me (with Ariana Grande)"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:1HY2Jd0NmPuamShAr6KMms",
-                "display": "Lady Gaga"
-            },
-            {
-                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
-                "display": "Ariana Grande"
-            }
-        ],
-        "release_date": "2020-05-22",
-        "popularity": 93,
-        "energy": 85,
-        "danceability": 67
-    },
-    {
-        "id": {
-            "value": "spotify:track:4HBZA5flZLE435QTztThqH",
-            "display": "Stuck with U (with Justin Bieber)"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR",
-                "display": "Ariana Grande"
-            },
-            {
-                "value": "spotify:artist:1uNFoZAHBGtllmzznpCI3s",
-                "display": "Justin Bieber"
-            }
-        ],
-        "release_date": "2020-05-08",
-        "popularity": 93,
-        "energy": 45,
-        "danceability": 59
-    },
-    {
-        "id": {
-            "value": "spotify:track:3nS9a01VvXHQriLqJYwRqG",
-            "display": "DOLLAZ ON MY HEAD (feat. Young Thug)"
-        },
-        "artists": [
-            {
-                "value": "spotify:artist:2hlmm7s2ICUX0LVIhVFlZQ",
-                "display": "Gunna"
-            },
-            {
-                "value": "spotify:artist:50co4Is1HCEo8bhOyUWKpn",
-                "display": "Young Thug"
-            }
-        ],
-        "release_date": "2020-05-22",
-        "popularity": 85,
-        "energy": 45,
-        "danceability": 82
     },
     {
         "id": {
@@ -3146,9 +4613,39 @@
                 "display": "Juice WRLD"
             }
         ],
+        "genres": [
+            "australian hip hop",
+            "pop rap",
+            "rap",
+            "trap"
+        ],
         "release_date": "2020-06-12",
         "popularity": 87,
         "energy": 74,
         "danceability": 54
+    },
+    {
+        "id": {
+            "value": "spotify:track:127QTOFJsJQp5LbJbu3A1y",
+            "display": "Toosie Slide"
+        },
+        "artists": [
+            {
+                "value": "spotify:artist:3TVXtAsR1Inumwj472S9r4",
+                "display": "Drake"
+            }
+        ],
+        "genres": [
+            "canadian hip hop",
+            "canadian pop",
+            "hip hop",
+            "pop rap",
+            "rap",
+            "toronto rap"
+        ],
+        "release_date": "2020-04-03",
+        "popularity": 92,
+        "energy": 45,
+        "danceability": 83
     }
 ]

--- a/test/unit/main/com.spotify.js
+++ b/test/unit/main/com.spotify.js
@@ -13,7 +13,7 @@ const Tp = require('thingpedia');
 module.exports = [
     ['query', 'song', {}, {
         filter: [
-            [ 'id', '=~', 'despacito' ]
+            ['id', '=~', 'despacito']
         ]
     }, (result) => {
         assert.deepStrictEqual(result[0], {
@@ -22,6 +22,7 @@ module.exports = [
                 new Tp.Value.Entity('spotify:artist:4VMYDCV2IEDYJArk749S6m', 'Daddy Yankee'),
                 new Tp.Value.Entity('spotify:artist:1uNFoZAHBGtllmzznpCI3s', 'Justin Bieber')
             ],
+            genres: ['latin', 'latin pop', 'puerto rican pop', 'tropical'],
             danceability: 65.3,
             energy: 81.6,
             popularity: 74,


### PR DESCRIPTION
Genre works in a really weird way with the Spotify API. Genre is a property of songs which you can filter by in the search endpoint, but there is no way to directly access the genre of the song. The best I could think of is check the artist of the song and then get the genre of the artist. However, this doesn't yield the right results all of the time. For example, Taylor Swift has genres pop and dance pop, but her song cardigan doesn't show up if you filter for dance pop songs, it only has genre pop. I also updated the evaluation sets to be in the correct thing talk form. 