### PR TITLE
Add commands for calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ synthetic*
 augmented*
 *user.tsv
 *agent.tsv
+calibration-ood.tsv
+calibration-ood-processed.tsv
 eval/*/schema*.tt
 eval/*/dataset.tt
 eval/*/database-map.tsv

--- a/scripts/calibrate.sh
+++ b/scripts/calibrate.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -e
+set -x
+
+rm -fr ./tmp/datadir
+mkdir -p ./tmp/datadir
+
+# first calibrate only on the in-domain dataset
+make datadir/fewshot
+ln -s ../../datadir/fewshot ./tmp/datadir/almond
+genienlp predict \
+ --path ./tmp/model \
+ --data ./tmp/datadir \
+ --eval_dir ./tmp/calibration-indomain \
+ --task almond_dialogue_nlu \
+ --silent \
+ --overwrite \
+ --evaluate valid \
+ --save_confidence_features \
+ --confidence_feature_path "./tmp/calibration-indomain/confidence_feature_file.pkl" \
+ --mc_dropout --mc_dropout_num 20 \
+ "$@"
+
+genienlp calibrate --save "./tmp/model" --confidence_path "./tmp/calibration-indomain/confidence_feature_file.pkl" --plot
+cp ./tmp/model/{calibrator.pkl,precision-recall.svg,threshold.svg,pass-accuracy.svg} ./tmp/calibration-indomain
+
+# now calibrate on the in-domain+out-of-domain dataset
+rm ./tmp/datadir/almond
+make datadir/calibration
+ln -s ../../datadir/calibration ./tmp/datadir/almond
+genienlp predict \
+  --path ./tmp/model \
+  --data ./tmp/datadir \
+  --eval_dir ./tmp/calibration-ood \
+  --task almond_dialogue_nlu \
+  --silent \
+  --overwrite \
+  --evaluate valid \
+  --save_confidence_features \
+  --confidence_feature_path "./tmp/calibration-ood/confidence_feature_file.pkl" \
+  --mc_dropout --mc_dropout_num 20 \
+  "$@"
+
+genienlp calibrate --save "./tmp/model" --confidence_path "./tmp/calibration-ood/confidence_feature_file.pkl" --plot
+cp ./tmp/model/{calibrator.pkl,precision-recall.svg,threshold.svg,pass-accuracy.svg} ./tmp/calibration-ood
+


### PR DESCRIPTION
Use `make datadir/calibration` to make a datadir that contains
validation data including OOD.

@s-jse this is how I got the calibration results today. `calibrate.sh` is for manual use, but the makefile bits could be integrated in the pipeline. We could pass calibration_ood_file to the Makefile during generation if calibration is enabled, then `datadir/calibration` will be available and can be symlinked in the right place.