### PR TITLE
Error messages for daily mix playlists

### DIFF
--- a/main/com.spotify/index.js
+++ b/main/com.spotify/index.js
@@ -534,6 +534,10 @@ module.exports = class SpotifyDevice extends Tp.BaseDevice {
             }
         }
 
+        if (idFilter.toLowerCase().includes("daily mix")) {
+            throwError('disallowed_action');
+        }
+
         let query = (idFilter + yearFilter + artistFilter + genreFilter).trim() || `year:${new Date().getFullYear()} `;
         if (idFilter) {
             let music = await this.music_by_search(query, 5);
@@ -813,6 +817,10 @@ module.exports = class SpotifyDevice extends Tp.BaseDevice {
                     else id = value;
                 }
             }
+        }
+
+        if (id.toLowerCase().includes("daily mix")) {
+            throwError('disallowed_action');
         }
 
         let query = id || `${new Date().getFullYear()}`;

--- a/main/com.spotify/manifest.tt
+++ b/main/com.spotify/manifest.tt
@@ -123,6 +123,9 @@ class @com.spotify
   #_[canonical=["music", "good music"]]
   #_[canonical_short=["music"]]
   #_[confirmation="playable content on Spotify"]
+  #_[on_error={
+    disallowed_action=["spotify doesn't support daily mix playlists at this time"]
+  }]
   #[minimal_projection=["id"]]
   #_[formatted=[{type="text",text="${id} by ${artists}"}]]
   #[doc="search for content on Spotify"];
@@ -205,6 +208,9 @@ class @com.spotify
                                          }])
   #_[canonical=["playlist"]]
   #_[confirmation="playlists on Spotify"]
+  #_[on_error={
+    disallowed_action=["spotify doesn't support daily mix playlists at this time"]
+  }]
   #[minimal_projection=["id"]]
   #_[formatted=[{type="text",text="${id}"}]]
   #[doc="search for playlists on Spotify"];


### PR DESCRIPTION
Spotify's API currently does not support searching for daily mix playlists. For now, we just return a custom error message.