### PR TITLE
Mark all home assistant devices as transient

### DIFF
--- a/main/io.home-assistant/base.js
+++ b/main/io.home-assistant/base.js
@@ -20,6 +20,7 @@ module.exports = class HomeAssistantDevice extends Tp.BaseDevice {
         this._entityId = entityId;
         this.uniqueId = master.uniqueId + '/' + entityId;
         this.name = this.state.attributes.friendly_name;
+        this.isTransient = true;
 
         this._clock = 0;
     }


### PR DESCRIPTION
Home Assistant devices are created on the fly by the gateway
device, and cannot be deleted from the UI. The "isTransient"
property should be set to reflect this.

This should fix the 404 error that @balloob reported. @almakantara can you test it doesn't break anything?