### PR TITLE
Add device names to all the IoT replies

### DIFF
--- a/main/org.thingpedia.iot.battery/manifest.tt
+++ b/main/org.thingpedia.iot.battery/manifest.tt
@@ -9,7 +9,7 @@ abstract class @org.thingpedia.iot.battery
   monitorable query state(out state : Enum(low,normal), out value : Number)
   #_[canonical="battery state"]
   #_[confirmation="the state of $__device"]
-  #_[result=["the battery level is ${value} %", "it is ${state} level of charging"]]
+  #_[result=["the battery level {of ${__device}|} is ${value} %", "the battery {of ${__device}} is ${state}"]]
   #[confirm=false]
   #[minimal_projection=["state", "value"]];
 }

--- a/main/org.thingpedia.iot.climate/manifest.tt
+++ b/main/org.thingpedia.iot.climate/manifest.tt
@@ -10,13 +10,13 @@ abstract class @org.thingpedia.iot.climate
   #_[canonical="get hvac current action"]
   #_[confirmation="what is doing your HVAC system"]
   #[confirm=false]
-  #_[result=["the HVAC system is ${action}"]];
-  
-  monitorable query hvac_modes_aval(out modes : Array(Enum(off,heat,cool,heat_cool,auto,dry,fan_only))) 
+  #_[result=["the {${__device}|} HVAC system is ${action}"]];
+
+  monitorable query hvac_modes_aval(out modes : Array(Enum(off,heat,cool,heat_cool,auto,dry,fan_only)))
   #_[canonical="get available HVAC modes"]
   #_[confirmation="the modes available for your HVAC system"]
   #[confirm=false]
-  #_[result=["the available modes are ${modes}"]];
+  #_[result=["the available modes {on ${__device}|} are ${modes}"]];
 
   action set_hvac_mode(in req mode: Enum(heat,cool,heat_cool,off,auto,dry,fan_only) #_[prompt="What mode do you want to set?"] #_[canonical="mode"])
   #_[canonical="set HVAC mode"]
@@ -27,13 +27,13 @@ abstract class @org.thingpedia.iot.climate
   #_[canonical="get hvac current preset"]
   #_[confirmation="how is set your HVAC system"]
   #[confirm=false]
-  #_[result=["the HVAC system is set to ${preset}"]];
+  #_[result=["the {${__device}|} HVAC system is set to ${preset}"]];
 
-  monitorable query hvac_presets_aval(out presets : Array(Enum(eco,away,boost,comfort,home,sleep,activity))) 
+  monitorable query hvac_presets_aval(out presets : Array(Enum(eco,away,boost,comfort,home,sleep,activity)))
   #_[canonical="get available HVAC presets"]
   #_[confirmation="the presets available for your HVAC system"]
   #[confirm=false]
-  #_[result=["the available presets are ${presets}"]];
+  #_[result=["the available presets {on ${__device}|} are ${presets}"]];
 
   action set_hvac_preset(in req preset: Enum(eco,away,boost,comfort,home,sleep,activity) #_[prompt="What preset do you want to set?"] #_[canonical="preset"])
   #_[canonical="set HVAC preset"]
@@ -44,13 +44,13 @@ abstract class @org.thingpedia.iot.climate
   #_[canonical="get current temperature"]
   #_[confirmation="the temperature from your thermostat"]
   #[confirm=false]
-  #_[result=["the temperature is ${value}"]];
+  #_[result=["the temperature {reported by ${__device}|} is ${value}"]];
 
   monitorable query target_temperature(out value : Measure(C))
   #_[canonical="get current target temperature set"]
   #_[confirmation="the target temperature set on your thermostat"]
   #[confirm=false]
-  #_[result=["the target temperature is set to ${value}"]];
+  #_[result=["the target temperature {on ${__device}|} is set to ${value}"]];
 
   action set_target_temperature(in req value: Measure(C))
   #_[canonical="set target temperature on thermostat"]
@@ -67,25 +67,25 @@ abstract class @org.thingpedia.iot.climate
   #_[canonical="get minimum temperature limit set"]
   #_[confirmation="the minimun range limit of temperatures set on your thermostat"]
   #[confirm=false]
-  #_[result=["the minimun temperature is set to ${low}"]];
+  #_[result=["the minimum temperature {on ${__device}|} is set to ${low}"]];
 
   monitorable query max_temperature(out high : Measure(C))
   #_[canonical="get maximum temperature limit set"]
   #_[confirmation="the maximum range limit of temperatures set on your thermostat"]
   #[confirm=false]
-  #_[result=["the maximum temperature is set to  ${high} "]];
+  #_[result=["the maximum temperature {on ${__device}|} is set to  ${high} "]];
 
   monitorable query current_humidity(out value : Number)
   #_[canonical="get current humidity"]
   #_[confirmation="the humidity from your thermostat"]
   #[confirm=false]
-  #_[result=["the humidity is ${value}"]];
+  #_[result=["the humidity {reported by ${__device}|} is ${value}"]];
 
   monitorable query target_humidity(out value : Number)
   #_[canonical="get current target humidity set"]
   #_[confirmation="the target humidity set on your thermostat"]
   #[confirm=false]
-  #_[result=["the target humidity is set to ${value}"]];
+  #_[result=["the target humidity {on ${__device}|} is set to ${value}"]];
 
   action set_target_humidity(in req value: Number)
   #_[canonical="set target humidity on thermostat"]
@@ -96,25 +96,25 @@ abstract class @org.thingpedia.iot.climate
   #_[canonical="get minimum humidity limit set"]
   #_[confirmation="the minimun range limit of humidity set on your thermostat"]
   #[confirm=false]
-  #_[result=["the minimun humidity is set to ${low}"]];
+  #_[result=["the minimun humidity {on ${__device}|} is set to ${low}"]];
 
   monitorable query max_humidity(out high : Number)
   #_[canonical="get maximum humidity limit set"]
   #_[confirmation="the maximum range limit of humidity set on your thermostat"]
   #[confirm=false]
-  #_[result=["the maximum humidity is set to  ${high} "]];
+  #_[result=["the maximum humidity {on ${__device}|} is set to  ${high} "]];
 
   monitorable query fan_mode(out mode: Enum(on,off,auto,low,medium,high,middle,focus,diffuse))
   #_[canonical="get current fan mode"]
   #_[confirmation="how is set your fan mode"]
   #[confirm=false]
-  #_[result=["the fan mode is set to ${mode}"]];
+  #_[result=["the fan mode {on ${__device}|} is set to ${mode}"]];
 
-  monitorable query fan_modes_aval(out modes : Array(Enum(on,off,auto,low,medium,high,middle,focus,diffuse))) 
+  monitorable query fan_modes_aval(out modes : Array(Enum(on,off,auto,low,medium,high,middle,focus,diffuse)))
   #_[canonical="get available fan modes"]
   #_[confirmation="the fan modes available for your system"]
   #[confirm=false]
-  #_[result=["the available fan modes are ${modes}"]];
+  #_[result=["the available fan modes {on ${__device}|} are ${modes}"]];
 
   action set_fan_mode(in req mode: Enum(on,off,auto,low,medium,high,middle,focus,diffuse))
   #_[canonical="set fan mode"]
@@ -125,13 +125,13 @@ abstract class @org.thingpedia.iot.climate
   #_[canonical="get current swing mode"]
   #_[confirmation="how is set your swing mode"]
   #[confirm=false]
-  #_[result=["the swing mode is set to ${mode}"]];
+  #_[result=["the swing mode {on ${__device}|} is set to ${mode}"]];
 
-  monitorable query swing_modes_aval(out modes : Array(Enum(on,off,auto,low,medium,high,middle,focus,diffuse))) 
+  monitorable query swing_modes_aval(out modes : Array(Enum(on,off,auto,low,medium,high,middle,focus,diffuse)))
   #_[canonical="get available swing modes"]
   #_[confirmation="the swing modes available for your system"]
   #[confirm=false]
-  #_[result=["the available swing modes are ${modes}"]];
+  #_[result=["the available swing modes {on ${__device}|} are ${modes}"]];
 
   action set_swing_mode(in req mode: Enum(on,off,auto,low,medium,high,middle,focus,diffuse))
   #_[canonical="set swing mode"]

--- a/main/org.thingpedia.iot.cover/manifest.tt
+++ b/main/org.thingpedia.iot.cover/manifest.tt
@@ -10,7 +10,7 @@ abstract class @org.thingpedia.iot.cover
   #_[canonical="cover state"]
   #_[confirmation="the state of $__device"]
   #[confirm=false]
-  #_[result=["the cover is ${state}"]];
+  #_[result=["the {${__device}|} cover is ${state}"]];
 
   action set_openclose(in req state: Enum(open,close) #_[prompt="Do you want to open or close it?"] #_[canonical="state"])
   #_[canonical="open or close cover"]

--- a/main/org.thingpedia.iot.door/manifest.tt
+++ b/main/org.thingpedia.iot.door/manifest.tt
@@ -10,5 +10,5 @@ abstract class @org.thingpedia.iot.door
   #_[canonical="door state"]
   #_[confirmation="the state of $__device"]
   #[confirm=false]
-  #_[result=["the entrance is ${state}"]];
+  #_[result=["the {${__device}|} entrance is ${state}"]];
 }

--- a/main/org.thingpedia.iot.fan/manifest.tt
+++ b/main/org.thingpedia.iot.fan/manifest.tt
@@ -9,7 +9,7 @@ abstract class @org.thingpedia.iot.fan
   monitorable query state(out state : Enum(on,off))
   #_[canonical="fan state"]
   #_[confirmation="the state of $__device"]
-  #_[result=["the fan is $state"]];
+  #_[result=["the {${__device}|} fan is $state"]];
 
   action set_power(in req power: Enum(on,off) #_[prompt="Do you want to turn it on or off?"] #_[canonical="power"])
   #_[canonical="set power on fan"]
@@ -19,7 +19,7 @@ abstract class @org.thingpedia.iot.fan
   monitorable query oscillation(out state : Enum(oscillating,not_oscillating))
   #_[canonical="fan oscillation state"]
   #_[confirmation="the oscillation of $__device"]
-  #_[result=["the fan is ${state:enum}"]];
+  #_[result=["the {${__device}|} fan is ${state:enum}"]];
 
   action set_oscillation(in req oscillation: Enum(on,off) #_[prompt="Do you want to turn oscillation on or off?"] #_[canonical="oscillation"])
   #_[canonical="set oscillation on fan"]

--- a/main/org.thingpedia.iot.flood/manifest.tt
+++ b/main/org.thingpedia.iot.flood/manifest.tt
@@ -9,7 +9,7 @@ abstract class @org.thingpedia.iot.flood
   monitorable query flood(out state : Enum(flooding,not_flooding), out value : Number)
   #_[canonical="flood sensor state"]
   #_[confirmation="the flood state from $__device"]
-  #_[result=["the flood level is ${value}", "it is ${state}"]]
+  #_[result=["the flood level {reported by ${__device}|} is ${value}", "the {${__device}|} flood sensor reports ${state}"]]
   #[confirm=false]
   #[minimal_projection=["state", "value"]];
 }

--- a/main/org.thingpedia.iot.humidity/manifest.tt
+++ b/main/org.thingpedia.iot.humidity/manifest.tt
@@ -15,7 +15,7 @@ abstract class @org.thingpedia.iot.humidity
                  "whether it is humid in the room",
                  "if it is humid"]]
   #_[confirmation="the humidity from $__device"]
-  #_[result=["the humidity level is ${value} percent", "it is ${state} in the room"]]
+  #_[result=["the humidity level {reported by ${__device}|} is ${value} percent", "it is ${state} in the room {according to ${__device}|}"]]
   #[confirm=false]
   #[minimal_projection=["state", "value"]];
 }

--- a/main/org.thingpedia.iot.illuminance/manifest.tt
+++ b/main/org.thingpedia.iot.illuminance/manifest.tt
@@ -10,5 +10,5 @@ abstract class @org.thingpedia.iot.illuminance
   #_[canonical="illuminance sensor value"]
   #_[confirmation="the illuminance from $__device"]
   #[confirm=false]
-  #_[result=["the illuminance level is ${value}"]];
+  #_[result=["the illuminance level {reported by ${__device}|} is ${value}"]];
 }

--- a/main/org.thingpedia.iot.light-bulb/manifest.tt
+++ b/main/org.thingpedia.iot.light-bulb/manifest.tt
@@ -12,7 +12,7 @@ abstract class @org.thingpedia.iot.light-bulb extends @org.thingpedia.iot.switch
                 "light state"]]
   #_[confirmation="the power state of ${__device}"]
   #[confirm=false]
-  #_[result=["your lights are ${power}"]];
+  #_[result=["your {${__device}|} lights are ${power}"]];
 
   action alert_long()
   #_[canonical=["loop the color in my light bulb",
@@ -51,7 +51,7 @@ abstract class @org.thingpedia.iot.light-bulb extends @org.thingpedia.iot.switch
   #_[canonical=["change the brightness of the light", "set the brightness on the lamp"]]
   #_[confirmation="set ${__device} $pct percent"]
   #[min_number=0]
-  #[max_number=100] 
+  #[max_number=100]
   #[confirm=false];
 
   action raise_brightness()

--- a/main/org.thingpedia.iot.lock/manifest.tt
+++ b/main/org.thingpedia.iot.lock/manifest.tt
@@ -10,7 +10,7 @@ abstract class @org.thingpedia.iot.lock
   #_[canonical="lock state"]
   #_[confirmation="the state of $__device"]
   #[confirm=false]
-  #_[result=["the lock is ${state}"]];
+  #_[result=["the {${__device}|} lock is ${state}"]];
 
   action set_state(in req state: Enum(lock,unlock) #_[prompt="Do you want to lock or unlock?"] #_[canonical="state"])
   #_[canonical="lock or unlock"]

--- a/main/org.thingpedia.iot.motion/manifest.tt
+++ b/main/org.thingpedia.iot.motion/manifest.tt
@@ -10,5 +10,5 @@ abstract class @org.thingpedia.iot.motion
   #_[canonical="motion detection state"]
   #_[confirmation="whether $__device detected motion"]
   #[confirm=false]
-  #_[result=["the motion detector is ${state} movement"]];
+  #_[result=["the {${__device}|} motion detector is ${state} movement"]];
 }

--- a/main/org.thingpedia.iot.temperature/manifest.tt
+++ b/main/org.thingpedia.iot.temperature/manifest.tt
@@ -17,5 +17,5 @@ abstract class @org.thingpedia.iot.temperature
                 "the temperature in the room"]]
   #_[confirmation="the temperature from $__device"]
   #[confirm=false]
-  #_[result=["the temperature is ${value}"]];
+  #_[result=["the temperature {reported by ${__device}|} is ${value}"]];
 }

--- a/main/org.thingpedia.iot.uv/manifest.tt
+++ b/main/org.thingpedia.iot.uv/manifest.tt
@@ -10,5 +10,5 @@ abstract class @org.thingpedia.iot.uv
   #_[canonical="uv sensor state"]
   #_[confirmation="the uv from $__device"]
   #[confirm=false]
-  #_[result=["the uv level is ${value} uv"]];
+  #_[result=["the uv level {reported by ${__device}|} is ${value} uv"]];
 }

--- a/main/org.thingpedia.iot.vacuum/manifest.tt
+++ b/main/org.thingpedia.iot.vacuum/manifest.tt
@@ -10,7 +10,7 @@ abstract class @org.thingpedia.iot.vacuum
   #_[canonical=["the state of my vacuum", "whether the vacuum is on or off or docked", "vacuum state"]]
   #_[confirmation="the state of your vacuum"]
   #[confirm=false]
-  #_[result=["Your vacuum is ${state}", "It is ${status}"]];
+  #_[result=["Your {${__device}|} vacuum is ${state}", "Your {${__device}|} vacuum is ${status}"]];
 
   action set_power(in req power: Enum(on,off) #_[prompt="Do you want to turn it on or off?"] #_[canonical="power"])
   #_[canonical="set the power of the vacuum"]
@@ -36,5 +36,5 @@ abstract class @org.thingpedia.iot.vacuum
   #_[canonical="dock vacuum"]
   #_[confirmation="dock $__device"]
   #[confirm=true];
-  
+
 }


### PR DESCRIPTION
Otherwise, when multiple devices of the same type are available,
the assistant repeats the same message multiple times.