### PR TITLE
Add documentation for the scripts used to analyze/annotate the logs

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -8,4 +8,5 @@
 - [Training a model](training.md)
 - [Adding a new device](adding-new-device.md)
 - [Maintainer guide](maintainer.md)
+- [Analyzing conversation logs](log-processing.md)
 

--- a/doc/log-processing.md
+++ b/doc/log-processing.md
@@ -1,0 +1,101 @@
+# Processing and Analyzing Conversation Logs
+
+This document details the procedures to analyze the commands
+collected from users who have agreed to participate in our
+research and share their commands with us.
+
+There are two type of logs:
+- "passive" logs, which contain only the delexicalized context and
+  command. These logs are enabled by agreeing to the consent form
+  on any platform.
+- "recording" logs, which contain the full conversation, including
+  the precise context and agent reply, fully lexicalized, as well
+  as any up/downvotes from the user and their feedback. These logs
+  are enabled by "Enable recording" in a Web Almond instance.
+
+## Processing Passive Logs
+
+### Step 1: Download the logs
+
+```bash
+./scripts/download-dataset.sh --db {prod|dev} --type log > log.tsv
+aws s3 cp s3://geniehai/gcampax/dropped-log.tsv dropped-log.tsv
+```
+
+The first command downloads the new log. Direct MySQL access to
+almond-cloud is required to run the first command.
+
+The second command downloads the shared copy of the previously dropped sentences.
+Dropped sentences are previously-annotated sentences that are not representable in ThingTalk
+for various reasons; we use them mainly for OOD detection.
+
+### Step 2: Annotate the logs
+
+```bash
+./scripts/annotate-log.js --dropped dropped-log.tsv --id-prefix log log.tsv
+```
+
+Replace `--id-prefix log` with `--id-prefix log-dev` if annotating data
+from dev.almond.stanford.edu.
+
+The interface is similar to `genie manual-annotate-dialog`: you are presented
+with a sentence and its possible interpretation. You can edit an interpretation
+with `e $n`, or type a new ThingTalk dialogue state. You can drop the sentence
+with `d` followed by a reason.
+
+Use `?` to see the list of valid commands, including the list of valid reasons
+to drop a sentence and their abbreviations.
+
+### Step 3: Edit previously-annotated OOD logs
+
+When new functionality is added to Genie, commands that were previously OOD
+can become representable in ThingTalk. In that case, we need to reannotate
+some of those sentences. To do so:
+
+```bash
+./scripts/annotate-log.js --dropped dropped-log.tsv --id-prefix log log.tsv \
+  --edit-existing $reason
+```
+
+Where `$reason` is a reason to drop the sentence listed in dropped-log.tsv.
+Use `cut -f3 dropped-log.tsv | sort -u` to see all possible reasons.
+
+The tool will list all the sentences in `log.tsv` whose ID is marked in dropped-log.tsv
+with the given reason. It is then possible to annotate each sentence with
+ThingTalk, drop the sentence again with the same reason, or with a different
+reason.
+
+**It is highly recommended to make a backup of dropped-log.tsv before executing the command, and check the diff, to avoid data loss.**
+
+## Processing Recording Logs
+
+### Step 1: Download the logs
+
+```bash
+./scripts/analyze-recordings.sh
+```
+
+The script will download new recording files to `./logs/new/`.
+
+It is possible to analyze the recordings manually to look for downvotes
+or comments. After looking at the logs, the files should be moved to `./logs/seen/`.
+
+### Step 2: Annotate the logs
+
+```bash
+./scripts/recording-to-devset.js
+```
+
+The interface is similar to `genie manual-annotate-dialog` and `./scripts/annotate-log.js`.
+Each dialogue is truncated when the ThingTalk recorded in the log is incorrect,
+which would cause the conversation to diverge from the recording.
+A dialogue can be truncated explicitly with the `d` command.
+The `d` command also adds a note to `./logs/dropped.tsv`.
+
+Dialogues whose ID is already present anywhere in the dev set, few-shot
+training set, or in `./logs/dropped.tsv`, are not processed again, and
+need to be edited manually.
+
+Note that the convention for the reasons to drop a dialogue is different than the
+convention used for dropped-log.tsv, because all out-of-domain dialogues
+are grouped under the `ood` category. Use `?` to see the list of reasons.

--- a/doc/maintainer.md
+++ b/doc/maintainer.md
@@ -25,11 +25,12 @@ To deploy the new model as the default model for dev.almond.stanford.edu.
 
 Use:
 ```bash
-./scripts/download-dataset.sh -t $type > dataset.tsv
+./scripts/download-dataset.sh --db {prod|dev} --type $type > dataset.tsv
 ```
-where `$type` is `online` for Train Almond and `turking%` for MTurk paraphrasing.
+where `$type` is `online` for Train Almond, `turking%` for MTurk paraphrasing, `log` for
+passively-collected sentences.
 
-You need a working `prod-mysql-run` command to use this script.
+You need a working `prod-mysql-run` or `dev-mysql-run` command to use this script.
 
 For paraphrase, you should requote the dataset:
 ```

--- a/main/com.smartnews/eval/dev/annotated.txt
+++ b/main/com.smartnews/eval/dev/annotated.txt
@@ -234,3 +234,8 @@ UT: @com.smartnews.article() filter title =~ "covid";
 U: another news
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: @com.smartnews.article();
+====
+# log-dev/199
+U: show me news about trump
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @com.smartnews.article() filter title =~ "trump";

--- a/package-lock.json
+++ b/package-lock.json
@@ -402,9 +402,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.21.tgz",
-      "integrity": "sha512-gwCiEZqW6f7EoR8TTEfalyEhb1zA5jQJnRngr97+3pzMaO1RKoI1w2bw07TK72renMUVWcWS5mLI6rk1NqN0nA==",
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.22.tgz",
+      "integrity": "sha512-WdqmrUsRS4ootGha6tVwk/IVHM1iorU8tGehftQD2NWiPniw/sm7xdJOIlXLwqdInL9wBw/p7oO8vaYEF3NDmA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1136,9 +1136,9 @@
       "dev": true
     },
     "coveralls": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
+      "integrity": "sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.13.1",
@@ -2056,7 +2056,7 @@
       }
     },
     "genie-toolkit": {
-      "version": "github:stanford-oval/genie-toolkit#c1a5a9571e3fa97ff8040b84deb230d7ea75405f",
+      "version": "github:stanford-oval/genie-toolkit#72d9ffae84518d35095cb8d3a6bd243572c5c320",
       "from": "github:stanford-oval/genie-toolkit",
       "dev": true,
       "requires": {
@@ -2066,7 +2066,7 @@
         "body-parser": "^1.19.0",
         "byline": "^5.0.0",
         "consumer-queue": "^1.0.0",
-        "csv-parse": "^4.15.4",
+        "csv-parse": "^4.16.0",
         "csv-stringify": "^5.6.2",
         "deep-equal": "^2.0.5",
         "en-inflectors": "^1.0.12",
@@ -2083,7 +2083,7 @@
         "mmap-io": "^1.1.7",
         "morgan": "^1.9.1",
         "node-gettext": "^3.0.0",
-        "nodemailer": "^6.6.1",
+        "nodemailer": "^6.6.2",
         "q": "^1.5.0",
         "qs": "^6.10.1",
         "query-validation": "^0.2.1",
@@ -2092,13 +2092,13 @@
         "sqlite3": "5.0.2",
         "stemmer": "^1.0.5",
         "string-interp": "^0.3.1",
-        "thingpedia": "github:stanford-oval/thingpedia-api",
-        "thingtalk": "github:stanford-oval/thingtalk",
+        "thingpedia": "~2.10.0-alpha.1",
+        "thingtalk": "~2.1.0-alpha.1",
         "thingtalk-units": "^0.2.0",
-        "twilio": "^3.63.1",
+        "twilio": "^3.64.0",
         "typescript": "~4.2.4",
         "uuid": "^8.2.0",
-        "ws": "^7.4.6"
+        "ws": "^7.5.0"
       },
       "dependencies": {
         "form-data": {
@@ -4319,13 +4319,14 @@
       "dev": true
     },
     "thingpedia": {
-      "version": "github:stanford-oval/thingpedia-api#50d8f44ced25e4e8005c179969df20be861df871",
-      "from": "github:stanford-oval/thingpedia-api",
+      "version": "2.10.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/thingpedia/-/thingpedia-2.10.0-alpha.1.tgz",
+      "integrity": "sha512-LRpdHKX7HFcqoqU5cogQcT4C5fp3omgqMFT2g4AlxuM6D93x9kI6Kny2VD+O/NW3gvyTZRS0ByfztiZ0XNiiWQ==",
       "dev": true,
       "requires": {
         "@types/feedparser": "^2.2.3",
         "@types/ip": "^1.1.0",
-        "@types/node": "^15.6.0",
+        "@types/node": "^15.12.5",
         "@types/node-gettext": "^3.0.1",
         "@types/qs": "^6.9.5",
         "@types/xml2js": "^0.4.8",
@@ -4340,6 +4341,12 @@
         "xml2js": "^0.4.17"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "15.12.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+          "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+          "dev": true
+        },
         "qs": {
           "version": "6.10.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
@@ -4352,8 +4359,9 @@
       }
     },
     "thingtalk": {
-      "version": "github:stanford-oval/thingtalk#416e4d0ff55c55ff458185ac2e0b798b921b01a5",
-      "from": "github:stanford-oval/thingtalk",
+      "version": "2.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/thingtalk/-/thingtalk-2.1.0-alpha.1.tgz",
+      "integrity": "sha512-wzgeQQElnqZByL2+36ntcxGBS9u2XCcf8upHCLoNn3lIjgG1ttrPil9lHJkJS85YECENcvN45xcSFtxtJdbq8w==",
       "dev": true,
       "requires": {
         "@types/semver": "^7.3.6",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "devDependencies": {
     "argparse": "^2.0.1",
     "byline": "^5.0.0",
-    "coveralls": "^3.1.0",
+    "coveralls": "^3.1.1",
     "eslint": "^7.29.0",
     "genie-toolkit": "github:stanford-oval/genie-toolkit",
     "nyc": "^15.1.0",
     "seedrandom": "^3.0.5",
-    "thingpedia": "github:stanford-oval/thingpedia-api",
+    "thingpedia": "~2.10.0-alpha.1",
     "uuid": "^8.3.2"
   },
   "scripts": {

--- a/scripts/annotate-log.js
+++ b/scripts/annotate-log.js
@@ -719,7 +719,7 @@ async function main() {
     const tpClient = new Tp.HttpClient(platform, 'https://dev.almond.stanford.edu/thingpedia');
 
     const lines = await readAllLines(args.input)
-        .pipe(new Genie.DatasetParser({ contextual: false }))
+        .pipe(new Genie.DatasetParser({ contextual: true }))
         .pipe(new StreamUtils.ArrayAccumulator())
         .read();
 

--- a/scripts/annotate-log.js
+++ b/scripts/annotate-log.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
 //
 // This file is part of Genie
@@ -150,6 +151,10 @@ class Trainer {
                 if (!comment && this._comment)
                     comment = this._comment;
                 comment = SHORTHAND_COMMENT[comment] || comment;
+                if (comment.startsWith('nf/'))
+                    comment = 'new function/' + comment.substring(3);
+                else if (comment.startsWith('nd/'))
+                    comment = 'new device/' + comment.substring(3);
                 this._drop(comment);
                 return;
             }
@@ -201,6 +206,8 @@ class Trainer {
         console.log(`d redacted : drop the example, and hide the sentence from the dropped log`);
         for (const key in SHORTHAND_COMMENT)
             console.log(`d ${key} : drop the example as ${SHORTHAND_COMMENT[key]}`);
+        console.log(`d nf/$device : drop the example as new-function, with the device responsible for it`);
+        console.log(`d nd/$domain : drop the example as new-device, with a short string identifying the device`);
 
         this._rl.prompt();
     }

--- a/scripts/lib/platform.js
+++ b/scripts/lib/platform.js
@@ -83,7 +83,7 @@ class MockPlatform extends Tp.BasePlatform {
     }
 
     getWritableDir() {
-        return this._filesDir;
+        return os.homedir() + './.config/genie-toolkit';
     }
 
     getTmpDir() {

--- a/scripts/make-calibration-ood.sh
+++ b/scripts/make-calibration-ood.sh
@@ -8,8 +8,15 @@ test -f dropped-log.tsv || aws s3 cp s3://geniehai/gcampax/dropped-log.tsv dropp
 # These are in-domain: ok|contextual command|ambiguous|meta-command|skill-help|stream|timer
 # We ignore these: bug-tokenize|dialogue-model|redacted
 # out of domain:
-sed -E -e '/\t(chatty|faq|foreign language|junk|math|new device|new function|phone|policy or remote program|question|schemaorg|tutorial|unintellegible|web search)$/!d' -e 's/\t/\tnull\t/' -e 's/\t[^\t]*$/\t\$ood ;/' dropped-log.tsv > calibration-ood.tsv
-# junk
-sed -E -e '/\t(junk)$/!d' -e 's/\t/\tnull\t/' -e 's/\t[^\t]*$/\t\$junk ;/' dropped-log.tsv > calibration-junk.tsv
+sed -E -e '/\t(chatty|faq|foreign language|junk|math|new device.*|new function.*|phone|policy or remote program|question|schemaorg|tutorial|unintellegible|web search|junk)$/!d' -e 's/\t/\tnull\t/' -e 's/\t[^\t]*$/\t\$ood ;/' dropped-log.tsv > calibration-ood.tsv
+
+# Add all the commands that come in the staging devices (which are implicitly "new device")
+make release=staging eval/staging/schema.tt
+genie dialog-to-contextual -o staging-devtrain.tsv --thingpedia eval/staging/schema.tt \
+  --side user --flags E --id-prefix staging/ --deduplicate --no-tokenized --ignore-errors \
+  staging/*/eval/dev/annotated.txt staging/*/eval/train/annotated.txt
+
+sed -E -e 's/\t\$dialogue.[\t]*$/\t\$ood ;/' staging-devtrain.tsv \
+  staging/*/eval/paraphrase.tsv >> calibration-ood.tsv
+
 aws s3 cp calibration-ood.tsv s3://geniehai/gcampax/calibration-ood.tsv
-aws s3 cp calibration-junk.tsv s3://geniehai/gcampax/calibration-junk.tsv

--- a/scripts/recording-to-devset.js
+++ b/scripts/recording-to-devset.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
 //
 // This file is part of Genie
@@ -160,7 +161,14 @@ class Trainer {
         console.log(`e $number : edit the selected thingtalk code`);
         console.log(`n : show more candidates`);
         console.log(`t : type in the thingtalk directly`);
-        console.log(`d $comment : drop the turn and truncate the dialogue, with the given reason`);
+        console.log(`d $comment : drop the turn and truncate the dialogue, with the given reason:`);
+        console.log(`- ood : the command is out-of-domain`);
+        console.log(`- \\t : the command was typed as \\t`);
+        console.log(`- bad-agent : the agent misbehaved in a way that makes continuation impossible`);
+        console.log(`- control : the command was a control command (stop, cancel, etc.)`);
+        console.log(`- lost-context : the context was reset due to a bug and the command cannot be interpreted`);
+        console.log(`- asr : the command was unintellegible due to ASR problems`);
+        console.log(`- unintellegible : the command was unintellegible for other reasons`);
 
         this._rl.prompt();
     }

--- a/staging/com.dropbox/eval/dev/annotated.txt
+++ b/staging/com.dropbox/eval/dev/annotated.txt
@@ -20,14 +20,14 @@ UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: now => @com.dropbox.get_space_usage() => notify;
 ====
 # online/ep68
-U: rename str:PATH_NAME::0: to str:PATH_NAME::1: in my dropbox drive
+U: rename foo.jpg to bar.jpg in my dropbox drive
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.dropbox.move(new_name="str:PATH_NAME::1:"^^tt:path_name, old_name="str:PATH_NAME::0:"^^tt:path_name);
+UT: now => @com.dropbox.move(new_name="foo.jpg"^^tt:path_name, old_name="bar.jpg"^^tt:path_name);
 ====
 # online/120497
 U: list folder my documents with size greater than 13 mb
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.dropbox.list_folder(folder_name="my documents")), file_size >= 13MB => notify;
+UT: now => (@com.dropbox.list_folder(folder_name="my documents"^^tt:path_name)), file_size >= 13MB => notify;
 ====
 # online/121208
 U: how much am i using on dropbox?
@@ -37,7 +37,7 @@ UT: now => @com.dropbox.get_space_usage() => notify;
 # online/121264
 U: list folder work
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.dropbox.list_folder(folder_name="work") => notify;
+UT: now => @com.dropbox.list_folder(folder_name="work"^^tt:path_name) => notify;
 ====
 # online/121376
 U: list files greater than 13 kb
@@ -47,7 +47,7 @@ UT: now => (@com.dropbox.list_folder(folder_name=$?)), file_size >= 13KB => noti
 # online/121439
 U: list files in my old stuff bigger than 13 mb
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => (@com.dropbox.list_folder(folder_name="my old stuff")), file_size >= 13MB => notify;
+UT: now => (@com.dropbox.list_folder(folder_name="my old stuff"^^tt:path_name)), file_size >= 13MB => notify;
 ====
 # online/337979
 U: hey almond how much am i using on dropbox?
@@ -57,12 +57,12 @@ UT: now => @com.dropbox.get_space_usage() => notify;
 # online/1477733
 U: list my documents on my dropbox
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.dropbox.list_folder(folder_name="my documents") => notify;
+UT: now => @com.dropbox.list_folder(folder_name="my documents"^^tt:path_name) => notify;
 ====
 # online/1477778
 U: list my dropbox my documents
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: now => @com.dropbox.list_folder(folder_name="my documents") => notify;
+UT: now => @com.dropbox.list_folder(folder_name="my documents"^^tt:path_name) => notify;
 ====
 # online/19737387
 U: dropbox files are less than 1 gb
@@ -132,12 +132,12 @@ UT: now => aggregate max file_size of (@com.dropbox.list_folder(folder_name=$?))
 # online/120609
 U: list folder phone pictures with size greater than 13 kb
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: @com.dropbox.list_folder(folder_name="phone pictures") filter file_size >= 13KB;
+UT: @com.dropbox.list_folder(folder_name="phone pictures"^^tt:path_name) filter file_size >= 13KB;
 ====
 # online/121373
 U: list files in dropbox in phone pictures
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: @com.dropbox.list_folder(folder_name="phone pictures");
+UT: @com.dropbox.list_folder(folder_name="phone pictures"^^tt:path_name);
 ====
 # online/62110267
 U: how much space do i have left on dropbox?
@@ -147,7 +147,7 @@ UT: @com.dropbox.get_space_usage();
 # online/62110268
 U: list the dropbox files in / foo
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: @com.dropbox.list_folder(folder_name="foo");
+UT: @com.dropbox.list_folder(folder_name="foo"^^tt:path_name);
 ====
 # online/62110284
 U: how much space do i have left in dropbox

--- a/staging/com.nytimes/eval/dev/annotated.txt
+++ b/staging/com.nytimes/eval/dev/annotated.txt
@@ -173,3 +173,8 @@ UT: attimer(time=[new Time(0, 0)]) => @com.nytimes.get_front_page();
 U: monitor the new york times
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: monitor(@com.nytimes.get_front_page());
+====
+# log-dev/144
+U: show me nyt articles about trump
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @com.nytimes.get_front_page() filter description =~ "trump";

--- a/staging/org.wikidata/eval/dev/annotated.txt
+++ b/staging/org.wikidata/eval/dev/annotated.txt
@@ -8,3 +8,58 @@ UT: @org.wikidata.person() filter contains(P39, "president of the united states"
 U: who is the person with twitter id boogiecousins
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: @org.wikidata.person() filter P2002 =~ "boogiecousins";
+====
+# log-dev/132
+U: who is the person with twitter id johnlennon
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "johnlennon";
+====
+# log-dev/162
+U: who is the person with twitter id lsanger
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "lsanger";
+====
+# log-dev/163
+U: who is the person with twitter username officielmmb
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "officielmmb";
+====
+# log-dev/165
+U: who is the person with twitter name evra
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "evra";
+====
+# log-dev/234
+U: who has date of birth equal to 1/2/2018 and given name is barack
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z") && P735 =~ "barack";
+====
+# log-dev/235
+U: who has date of birth equal to 1/2/2018 and given name is peter
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z") && P735 =~ "peter";
+====
+# log-dev/241
+U: list me the person with date of birth is 1/2/2018 and given name is barack
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z") && P735 =~ "barack";
+====
+# log-dev/246
+U: list me persons with date of birth 1/2/2018
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z");
+====
+# log-dev/258
+U: who is the person with twitter id boogiecounsins
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "boogiecounsins";
+====
+# log-dev/260
+U: list me persons with date of birth being 1/2/2018
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z");
+====
+# log-dev/264
+U: list me person with date of birth being 1/2/2018 and given name is barack
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z") && P735 =~ "barack";

--- a/staging/org.wikidata/eval/train/annotated.txt
+++ b/staging/org.wikidata/eval/train/annotated.txt
@@ -3,3 +3,53 @@
 U: who is the person with twitter username boogiecousins
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: @org.wikidata.person() filter P2002 =~ "boogiecousins";
+====
+# log-dev/134
+U: who is the person with twitter id silei
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "silei";
+====
+# log-dev/164
+U: who is the person with twitter username sashagrey
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "sashagrey";
+====
+# log-dev/166
+U: who is the person with twitter name kdtrey5
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P2002 =~ "kdtrey5";
+====
+# log-dev/168
+U: who has date of birth equal to 1/2/2018 and birth name barack
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P1477 =~ "barack" && P569 == new Date("2018-01-02T08:00:00.000Z");
+====
+# log-dev/238
+U: who has date of birth is 1/2/2018 and given name is barack
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z") && P735 =~ "barack";
+====
+# log-dev/239
+U: list me the person with date of birth is 1/2/2018
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z");
+====
+# log-dev/253
+U: list me the person with date of birth being 1/2/2018 and given name being barack
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z") && P735 =~ "barack";
+====
+# log-dev/256
+U: list me the person with date of birth being 1/2/2018
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z");
+====
+# log-dev/261
+U: list me persons with date of birth being 1/2/2018 and given name is barack
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z") && P735 =~ "barack";
+====
+# log-dev/263
+U: list me person with date of birth being 1/2/2018
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.wikidata.person() filter P569 == new Date("2018-01-02T08:00:00.000Z");


### PR DESCRIPTION
For myself and for others in the team who will be looking at logs.

@kevintangzero This PR adds some documentation for what I currently have as workflow
to analyze the conversation logs, both the detailed ones that we get with "Enable recording"
and the passive command logs that we get from almost all users.

The `analyze-recordings.sh` script is built for file-base logs and will need to be replaced
with the script you're building, but the rest might still be helpful.

I imagine you will also want to build some tools to automate some of this analysis, but
I think it's good to have these scripts for manual analysis under your belt.