### PR TITLE
Add radio skill to Almond

### DIFF
--- a/main/com.tunein/dataset.tt
+++ b/main/com.tunein/dataset.tt
@@ -1,0 +1,25 @@
+dataset @com.tunein language "en" {
+    query (p_query :String)  := @com.tunein.search_channel(query=p_query, count=p_count)
+    #_[utterances=["${p_query:const} channels on the radio",
+                   "radio channels named ${p_query}",
+                   "${p_query:const} radio channel",
+                   "first ${p_count:const} radio channels matching ${p_query:const}",
+                   "top ${p_count:const} radio channels matching ${p_query:const}"]];
+
+    stream  := monitor (@com.tunein.search_channel(query=p_query))
+    #_[utterances=["when there is a new track from the ${p_query:const} channel"]];
+
+    query  := @com.tunein.list_local_channels(count=p_count)
+    #_[utterances=["show me top ${p_count:const} radio channels in my area",
+                   "list radio channels in my area"]];
+
+    query  := @com.tunein.list_trending_channels(count=p_count)
+    #_[utterances=["show me top ${p_count:const} trending radio channels",
+                   "list trending radio channels",
+                   "hottest radio channels",
+                   "most popular radio channels"]];
+
+    action (p_query :String) := @com.tunein.play(query=p_query)
+    #_[utterances=["broadcast ${p_query:const} channel on the radio",
+                   "stream ${p_query:const} radio channel"]];
+}

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -16,5 +16,31 @@ module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
          this.description = 'Stream radio through TuneIn API';
     }
 
+    _get_tunein_response(req) {
+        return new Promise( (resolve, reject) => {
+            axios.get(req.url, req)
+                .then(response => { 
+                    if (response.data.head.status == HTTP_STATUS_OK) {
+                        let content = response.data.body;
+                        if ('c' in req.params && BROWSE_ITEMS.includes(req.params.c.toLowerCase())) {
+                            return resolve(content);
+                        } else if (content.find(item => item.text.toLowerCase() == 'stations')) {
+                            return resolve(
+                                content.filter(item => item.text.toLowerCase() == 'stations')
+                                       .flatMap(({children}) => children)
+                                       .filter(channel => (channel.type.toLowerCase() == 'audio' && channel.item.toLowerCase() == 'station'))
+                            );
+                        } else {
+                            return resolve(content.filter(channel => (channel.type.toLowerCase() == 'audio' && channel.item.toLowerCase() == 'station')));
+                        }; 
+                    } else {
+                        reject(response.data);
+                        return new Error(`HTTP request error: ${response.data.head.fault}`);
+                    }
+                })
+                .catch(err => throwError("streaming_service_unaccessible"));
+        }).catch(err => throwError("streaming_service_unaccessible"));
+    }
+
     
 };

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -7,6 +7,10 @@ const url = require('url');
 
 const BASE_URL = 'http://opml.radiotime.com';
 const CONTENT_TYPE = 'application/x-www-form-urlencoded';
+const HTTP_STATUS_OK = 200;
+const SEARCH_PARAM = '/Search.ashx';
+const BROWSE_PARAM = '/Browse.ashx';
+const BROWSE_ITEMS = ['trending', 'music', 'sports', 'talk'];
 
 module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
     constructor(engine, state) {
@@ -72,5 +76,17 @@ module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
             return this._get_channel_info(available_channels.slice(0,count));
     }
 
-    
+    async get_list_trending_channels({count = 0}) {
+        let req = {};
+        req.params = {};
+        req.url = BROWSE_PARAM;
+        req.params.c = 'trending';
+        const available_channels = await this._get_tunein_response(req);
+        if ([undefined, null, 0].includes(count))
+            return this._get_channel_info(available_channels);
+        else
+            return this._get_channel_info(available_channels.slice(0,count));
+    }
+
+
 };

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -42,5 +42,11 @@ module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
         }).catch(err => throwError("streaming_service_unaccessible"));
     }
 
+    _get_channel_info(ch_list) {
+        return ch_list.map(
+            (x) => (({text, subtext='', current_track='', now_playing_id='', URL='', formats='', image=''}) => ({text, subtext, current_track, now_playing_id, URL, formats, image}))(x)
+            );
+    }
+
     
 };

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Tp = require('thingpedia');
+const axios = require('axios');
+const axiosExtensions = require('axios-extensions');
+const url = require('url');
+
+const BASE_URL = 'http://opml.radiotime.com';
+const CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
+module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
+    constructor(engine, state) {
+         super(engine, state);
+         this.uniqueId = 'com.tunein';
+         this.name = 'Tunein';
+         this.description = 'Stream radio through TuneIn API';
+    }
+
+    
+};

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -13,11 +13,14 @@ const BROWSE_PARAM = '/Browse.ashx';
 const BROWSE_ITEMS = ['trending', 'music', 'sports', 'talk'];
 
 module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
-    constructor(engine, state) {
+    constructor(engine, state, args={}) {
          super(engine, state);
          this.uniqueId = 'com.tunein';
          this.name = 'Tunein';
          this.description = 'Stream radio through TuneIn API';
+         axios.defaults.headers.post['Content-Type'] = args.content_type || CONTENT_TYPE;
+         axios.defaults.baseURL = args.protocol || BASE_URL;
+         axios.defaults.params = { render: 'json' };
     }
 
     _get_tunein_response(req) {

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -88,5 +88,12 @@ module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
             return this._get_channel_info(available_channels.slice(0,count));
     }
 
-
+    async do_play({query}) {
+        let req = {};
+        req.params = {};
+        req.url = SEARCH_PARAM;
+        req.params.query = query;
+        const available_channels = await this._get_tunein_response(req);
+        return available_channels[0].URL;
+    }
 };

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -60,5 +60,17 @@ module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
             return this._get_channel_info(available_channels.slice(0,count));
     }
 
+    async get_list_local_channels({count=0}) {
+        let req = {};
+        req.params = {};
+        req.url = BROWSE_PARAM;
+        req.params.c = 'local';
+        const available_channels = await this._get_tunein_response(req);
+        if ([undefined, null, 0].includes(count))
+            return this._get_channel_info(available_channels);
+        else
+            return this._get_channel_info(available_channels.slice(0,count));
+    }
+
     
 };

--- a/main/com.tunein/device.js
+++ b/main/com.tunein/device.js
@@ -48,5 +48,17 @@ module.exports = class TuneinRadioDevice extends Tp.BaseDevice {
             );
     }
 
+    async get_search_channel({query, count = 0}) {
+        let req = {};
+        req.params = {};
+        req.url = SEARCH_PARAM;
+        req.params.query = query;
+        const available_channels = await this._get_tunein_response(req);
+        if ([undefined, null, 0].includes(count))
+            return this._get_channel_info(available_channels);
+        else
+            return this._get_channel_info(available_channels.slice(0,count));
+    }
+
     
 };

--- a/main/com.tunein/manifest.tt
+++ b/main/com.tunein/manifest.tt
@@ -39,5 +39,29 @@ class @com.tunein
   import loader from @org.thingpedia.v2();
   import config from @org.thingpedia.config.none();
 
+  monitorable query list search_channel(in req query: String
+                                        #_[prompt="Which channel do you want to stream?"] 
+                                        #[string_values="tt:search_query"],
+                                        in opt count: Number 
+                                        #_[prompt="How many search results do you want?"],
+                                        out text: String 
+                                        #[string_values="com.tunein:text"],
+                                        out subtext: String 
+                                        #[string_values="com.tunein:subtext"],
+                                        out current_track: String 
+                                        #[string_values="com.tunein:current_track"],
+                                        out now_playing_id: String 
+                                        #[string_values="com.tunein:now_playing_id"], 
+                                        out URL: Entity(tt:url)
+                                        out formats: String 
+                                        #[string_values="com.tunein:formats"],
+                                        image: Entity(tt:picture))
+  #_[canonical=["search radio channel", "find radio channel"]]
+  #_[confirmation="Radio channels matching $query"]
+  #_[formatted=[{type="rdl",webCallback="${URL}",displayTitle="${text}",displayText="${subtext}"}, {type="picture",url="${image}"}]]
+  #[poll_interval=100000ms]
+  #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
+  #[doc="search a specific internet radio channel"];
+
   
 }

--- a/main/com.tunein/manifest.tt
+++ b/main/com.tunein/manifest.tt
@@ -109,5 +109,17 @@ class @com.tunein
   #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
   #[doc="list the trending radio channels"];
 
+  action play(in req query: String
+              #[string_values="tt:search_query"]
+              #_[prompt=["which channel would you like to listen to?"]]
+              #_[canonical={
+                 base=["text"],
+                 property=["# radio", "# channel"]}],
+              out URL: Entity(tt:url))
+  #_[canonical=["listen to radio", "broadcast radio", "stream radio"]]
+  #_[confirmation="broadcasting the content on $text"]
+  #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
+  #[confirm=enum(auto)];
+
   
 }

--- a/main/com.tunein/manifest.tt
+++ b/main/com.tunein/manifest.tt
@@ -121,5 +121,19 @@ class @com.tunein
   #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
   #[confirm=enum(auto)];
 
-  
+  action player_play()
+  #_[canonical=["resume playing", "start playing again", 
+                "resume streaming", "resume streaming again", 
+                "resume broadcasting", "resume broadcasting again"]]
+  #_[confirmation="resume radio streaming"]
+  #[doc="resume streaming"]
+  #[confirm=false];
+
+  action player_pause()
+  #_[canonical=["pause playback", "pause my radio", 
+                "pause the radio", "stop playing",
+                "stop broadcasting"]]
+  #_[confirmation="pause radio streaming"]
+  #[doc="pause streaming"]
+  #[confirm=false];
 }

--- a/main/com.tunein/manifest.tt
+++ b/main/com.tunein/manifest.tt
@@ -63,5 +63,28 @@ class @com.tunein
   #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
   #[doc="search a specific internet radio channel"];
 
+  monitorable query list list_local_channels(in req query: String
+                                             #[string_values="tt:search_query"],
+                                             in opt count: Number 
+                                             #_[prompt="How many search results do you want?"],
+                                             out text: String 
+                                             #[string_values="com.tunein:text"],
+                                             out subtext: String 
+                                             #[string_values="com.tunein:subtext"],
+                                             out current_track: String 
+                                             #[string_values="com.tunein:current_track"],
+                                             out now_playing_id: String 
+                                             #[string_values="com.tunein:now_playing_id"], 
+                                             out URL: Entity(tt:url)
+                                             out formats: String 
+                                             #[string_values="com.tunein:formats"],
+                                             image: Entity(tt:picture))
+  #_[canonical="list local radio channels"]
+  #_[confirmation="Here are the available channels in your area"]
+  #_[formatted=[{type="rdl",webCallback="${URL},displayTitle="${title}",displayText="${description}"}, {type="picture",url="${image}"}]]
+  #[poll_interval=100000ms]
+  #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
+  #[doc="list all the available radio channels in your area"];
+
   
 }

--- a/main/com.tunein/manifest.tt
+++ b/main/com.tunein/manifest.tt
@@ -86,5 +86,28 @@ class @com.tunein
   #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
   #[doc="list all the available radio channels in your area"];
 
+  monitorable query list list_trending_channels(in req query: String
+                                                #[string_values="tt:search_query"],
+                                                in opt count: Number 
+                                                #_[prompt="How many search results do you want?"],
+                                                out text: String 
+                                                #[string_values="com.tunein:text"],
+                                                out subtext: String 
+                                                #[string_values="com.tunein:subtext"],
+                                                out current_track: String 
+                                                #[string_values="com.tunein:current_track"],
+                                                out now_playing_id: String 
+                                                #[string_values="com.tunein:now_playing_id"], 
+                                                out URL: Entity(tt:url)
+                                                out formats: String 
+                                                #[string_values="com.tunein:formats"],
+                                                image: Entity(tt:picture))
+  #_[canonical="list trending radio channels"]
+  #_[confirmation="Here are the trending channels"]
+  #_[formatted=[{type="rdl",webCallback="${URL},displayTitle="${title}",displayText="${description}"}, {type="picture",url="${image}"}]]
+  #[poll_interval=100000ms]
+  #_[on_error={streaming_service_unaccessible=["radio streaming service is currently unaccessible"]}]
+  #[doc="list the trending radio channels"];
+
   
 }

--- a/main/com.tunein/manifest.tt
+++ b/main/com.tunein/manifest.tt
@@ -1,0 +1,43 @@
+// Copyright 2021 TuneIn, Inc.
+//           2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Redistribution and use in source and binary forms, with or
+// without modification, are permitted provided that the following
+// conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class @com.tunein
+#_[thingpedia_name="Tunein"]
+#_[thingpedia_description="Listen to internet radio"]
+#_[canonical="radio"]
+#[license="BSD-3-Clause"]
+#[license_gplcompatible=true]
+#[subcategory="media"]
+{
+  import loader from @org.thingpedia.v2();
+  import config from @org.thingpedia.config.none();
+
+  
+}


### PR DESCRIPTION
# Overview
Adds an initial creation of the radio skill to Almond. The database is based on the TuneIn free internet radio services. Functionalities include:
- Searching for channels
- Showing trending channels
- Listing available channels in the local area
- Streaming the radio
- Pause and resume streaming

# Files
- main / com.tunein / manifest.tt (device descriptions)
- main / com.tunein / dataset.tt (natural language examples)
- main / com.tunein / device.js (device API)



