### PR TITLE
com.spotify: fix playing exactly one song

### DIFF
--- a/main/com.spotify/index.js
+++ b/main/com.spotify/index.js
@@ -1095,7 +1095,7 @@ module.exports = class SpotifyDevice extends Tp.BaseDevice {
         if (music.length === 1) {
             const uri = String(music[0]);
             let data;
-            if (uri.includes("episode") || uri.includes("song"))
+            if (uri.includes("episode") || uri.includes("track"))
                 data = { uris: [uri] };
             else
                 data = { context_uri: uri };


### PR DESCRIPTION
The song URI is "spotify:track:...", fix detecting that so we
pass it as "uri" and not "context_uri"

Reported by @rhulkb27 but I can repro as well