### PR TITLE
Allow synthesizing a mix of simple and complex commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,23 +41,47 @@ synthetic_flags ?= \
 	schema_org \
 	undefined_filter \
 	$(NULL)
+simple_synthetic_flags ?= \
+	$(synthetic_flags) \
+	nostream \
+	$(NULL)
 
-target_pruning_size ?= 250
+target_pruning_size ?= 200
 minibatch_size ?= 1000
 target_size ?= 1
-subdatasets ?= 6
-subdataset_ids := $(shell seq 1 $(subdatasets))
-max_turns ?= 4
+max_turns ?= 5
 max_depth ?= 8
+subdatasets ?= 6
+simple_target_pruning_size ?= 1000
+simple_minibatch_size ?= 5000
+simple_target_size ?= 1
+simple_max_turns ?= 2
+simple_max_depth ?= 6
+simple_subdatasets ?= 6
+
+subdataset_ids := $(shell seq 1 $(subdatasets))
+simple_subdatasets_ids := $(shell seq 1 $(simple_subdatasets))
 debug_level ?= 2
 subsample_thingpedia ?= 1
 update_canonical_flags ?= --algorithm bert,adj,bart --paraphraser-model ./models/paraphraser-bart
+
+all_synthetic_files := $(foreach v,$(simple_subdatasets_ids),eval/$(release)/synthetic-simple-$(v).txt) $(foreach v,$(subdataset_ids),eval/$(release)/synthetic-complex-$(v).txt)
+
 synthetic_expand_factor ?= 1
 quoted_paraphrase_expand_factor ?= 25
 noquote_paraphrase_expand_factor ?= 1
 quoted_fraction ?= 0.05
 
-generate_flags ?= $(foreach v,$(synthetic_flags),--set-flag $(v)) --target-pruning-size $(target_pruning_size) --max-turns $(max_turns) --maxdepth $(max_depth)
+generate_flags ?= \
+	$(foreach v,$(synthetic_flags),--set-flag $(v)) \
+	--target-pruning-size $(target_pruning_size) \
+	--max-turns $(max_turns) --maxdepth $(max_depth) \
+	-n $(target_size) -B $(minibatch_size)
+simple_generate_flags ?= \
+	$(foreach v,$(simple_synthetic_flags),--set-flag $(v)) \
+	--target-pruning-size $(simple_target_pruning_size) \
+	--max-turns $(simple_max_turns) --maxdepth $(simple_max_depth) \
+	-n $(simple_target_size) -B $(simple_minibatch_size)
 custom_gen_flags ?=
 
 auto_annotate_algorithm ?= bert,adj,bart
@@ -156,25 +180,37 @@ parameter-datasets.tsv:
 	wget -c --no-verbose https://almond-static.stanford.edu/test-data/paraphraser-bart.tar.xz
 	tar -C .embeddings -xvf paraphraser-bart.tar.xz
 
-eval/$(release)/synthetic-%.txt : $(schema_file) $(dataset_file) entities.json
+eval/$(release)/synthetic-complex-%.txt : $(schema_file) $(dataset_file) entities.json
 	if test $(subsample_thingpedia) = 1 ; then \
-	  cp $(schema_file) eval/$(release)/schema-$*.tt ; \
+	  cp $(schema_file) eval/$(release)/schema-complex-$*.tt ; \
 	else \
 	  $(genie) subsample-thingpedia \
-	    -o eval/$(release)/schema-$*.tt \
+	    -o eval/$(release)/schema-complex-$*.tt \
 	    --fraction $(subsample_thingpedia) \
 	    --random-seed $@ \
 	    $(schema_file) ; \
 	fi
 	$(genie) generate-dialogs \
 	  --locale en-US --target-language thingtalk \
-	  --thingpedia eval/$(release)/schema-$*.tt --entities entities.json --dataset $(dataset_file) \
-	  -o $@.tmp -f txt $(generate_flags) --debug $(debug_level) --log-prefix "$(notdir $@): " $(custom_gen_flags) --random-seed $@ \
-	  -n $(target_size) -B $(minibatch_size)
+	  --thingpedia eval/$(release)/schema-complex-$*.tt --entities entities.json --dataset $(dataset_file) \
+	  -o $@.tmp -f txt $(generate_flags) --debug $(debug_level) --log-prefix "$(notdir $@): " $(custom_gen_flags) --random-seed $@
 	mv $@.tmp $@
 
-eval/$(release)/synthetic.txt: $(foreach v,$(subdataset_ids),eval/$(release)/synthetic-$(v).txt)
-	cat $^ > $@
+eval/$(release)/synthetic-simple-%.txt : $(schema_file) $(dataset_file) entities.json
+	if test $(subsample_thingpedia) = 1 ; then \
+	  cp $(schema_file) eval/$(release)/schema-simple-$*.tt ; \
+	else \
+	  $(genie) subsample-thingpedia \
+	    -o eval/$(release)/schema-simple-$*.tt \
+	    --fraction $(subsample_thingpedia) \
+	    --random-seed $@ \
+	    $(schema_file) ; \
+	fi
+	$(genie) generate-dialogs \
+	  --locale en-US --target-language thingtalk \
+	  --thingpedia eval/$(release)/schema-simple-$*.tt --entities entities.json --dataset $(dataset_file) \
+	  -o $@.tmp -f txt $(simple_generate_flags) --debug $(debug_level) --log-prefix "$(notdir $@): " $(custom_gen_flags) --random-seed $@
+	mv $@.tmp $@
 
 eval/$(release)/synthetic-%.user.tsv : eval/$(release)/synthetic-%.txt $(schema_file)
 	$(genie) dialog-to-contextual \
@@ -183,7 +219,7 @@ eval/$(release)/synthetic-%.user.tsv : eval/$(release)/synthetic-%.txt $(schema_
 	  -o $@.tmp $<
 	mv $@.tmp $@
 
-eval/$(release)/synthetic.user.tsv: $(foreach v,$(subdataset_ids),eval/$(release)/synthetic-$(v).user.tsv)
+eval/$(release)/synthetic.user.tsv: $(patsubst %.txt,%.user.tsv,$(all_synthetic_files))
 	$(genie) deduplicate --contextual -o $@.tmp $^
 	mv $@.tmp $@
 
@@ -194,7 +230,7 @@ eval/$(release)/synthetic-%.agent.tsv : eval/$(release)/synthetic-%.txt $(schema
 	  -o $@.tmp $<
 	mv $@.tmp $@
 
-eval/$(release)/synthetic.agent.tsv: $(foreach v,$(subdataset_ids),eval/$(release)/synthetic-$(v).agent.tsv)
+eval/$(release)/synthetic.agent.tsv: $(patsubst %.txt,%.agent.tsv,$(all_synthetic_files))
 	$(genie) deduplicate --contextual -o $@.tmp $^
 	mv $@.tmp $@
 
@@ -309,7 +345,7 @@ datadir/fewshot: eval/$(release)/train/user.tsv eval/$(release)/dev/user.tsv eva
 	cp eval/$(release)/dev/agent.tsv $@/agent/eval.tsv
 	touch $@
 
-datadir: datadir/agent datadir/nlg datadir/user datadir/fewshot $(foreach v,$(subdataset_ids),eval/$(release)/synthetic-$(v).txt)
+datadir: datadir/agent datadir/nlg datadir/user datadir/fewshot $(all_synthetic_files)
 	cat eval/$(release)/synthetic-*.txt > $@/synthetic.txt
 	$(genie) measure-training-set $@ > $@/stats
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ simple_synthetic_flags ?= \
 	nostream \
 	$(NULL)
 
-target_pruning_size ?= 200
+target_pruning_size ?= 150
 minibatch_size ?= 1000
 target_size ?= 1
-max_turns ?= 5
+max_turns ?= 4
 max_depth ?= 8
 subdatasets ?= 6
-simple_target_pruning_size ?= 1000
+simple_target_pruning_size ?= 500
 simple_minibatch_size ?= 5000
 simple_target_size ?= 1
 simple_max_turns ?= 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,7 +2074,7 @@
       }
     },
     "genie-toolkit": {
-      "version": "github:stanford-oval/genie-toolkit#34a8299de8b3200ef3272c8f9a4fec105457182b",
+      "version": "github:stanford-oval/genie-toolkit#ca6ae14177d0add1d004d9be73329193b57f148b",
       "from": "github:stanford-oval/genie-toolkit",
       "dev": true,
       "requires": {
@@ -3367,9 +3367,9 @@
       "dev": true
     },
     "nodemailer": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.2.tgz",
-      "integrity": "sha512-YSzu7TLbI+bsjCis/TZlAXBoM4y93HhlIgo0P5oiA2ua9Z4k+E2Fod//ybIzdJxOlXGRcHIh/WaeCBehvxZb/Q==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.3.tgz",
+      "integrity": "sha512-faZFufgTMrphYoDjvyVpbpJcYzwyFnbAMmQtj1lVBYAUSm3SOy2fIdd9+Mr4UxPosBa0JRw9bJoIwQn+nswiew==",
       "dev": true
     },
     "nopt": {
@@ -4449,9 +4449,9 @@
       "dev": true
     },
     "twilio": {
-      "version": "3.65.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.65.0.tgz",
-      "integrity": "sha512-NCktK8H5JqFvIOJjKmxheNHsGFBQh0dhVJYCASpVLPw1/XvurwhpCFIyvufr+jmHPdMwu2UMpq6ERDC7Ya6qVg==",
+      "version": "3.66.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.66.0.tgz",
+      "integrity": "sha512-2jek7akXcRMusoR20EWA1+e5TQp9Ahosvo81wTUoeS7H24A1xbVQJV4LfSWQN4DLUY1oZ4d6tH2oCe/+ELcpNA==",
       "dev": true,
       "requires": {
         "axios": "^0.21.1",

--- a/travis/test-dataset.sh
+++ b/travis/test-dataset.sh
@@ -6,4 +6,4 @@ set -o pipefail
 
 # Test that we can generate a (small) dataset for the main + universe devices
 
-make release=universe subdatasets=1 target_pruning_size=20 max_turns=2 debug_level=2 parallel=1 datadir
+make release=universe subdatasets=1 simple_subdatasets=0 target_pruning_size=20 max_turns=2 debug_level=2 parallel=1 datadir


### PR DESCRIPTION
To bias the training data towards simple commands, do two separate
generations, with different sets of hyperparameters.

"Simple" generation is optimized for breadth: high pruning size
so we don't prune out commands, low depth and number of turns,
and compound commands disabled.

"Complex" generation is as before optimized for depth and complexity:
relatively low pruning size but high depth and number of turns.

---

I'm going to try this in Kubeflow to see how it fares, but comments welcome.