### PR TITLE
Fix interaction of Home Assistant and cloud sync

### DIFF
--- a/main/io.home-assistant/index.js
+++ b/main/io.home-assistant/index.js
@@ -190,10 +190,10 @@ module.exports = class HomeAssistantGateway extends Tp.BaseDevice {
         // no matter what, at the next restart the addon setup code will create
         // the new device with the new good token
         this.isTransient = !!state.isHassio;
+    }
 
-        if (!Tp.Helpers.Content.isPubliclyAccessible(state.hassUrl) &&
-            this.platform.type === 'cloud')
-            throw new Error(`Web Almond can only connect to publicly accessible Home Assistant instances`);
+    get ownerTier() {
+        return this.state.ownerTier || Tp.Tier.GLOBAL;
     }
 
     static async loadFromOAuth2(engine, accessToken, refreshToken, extraData) {
@@ -204,6 +204,7 @@ module.exports = class HomeAssistantGateway extends Tp.BaseDevice {
             hassUrl: HASS_URL,
             accessToken, refreshToken,
             accessTokenExpires: expires,
+            ownerTier: engine.ownTier,
         });
     }
 
@@ -275,6 +276,10 @@ module.exports = class HomeAssistantGateway extends Tp.BaseDevice {
     }
 
     async start() {
+        if (!Tp.Helpers.Content.isPubliclyAccessible(this.state.hassUrl) &&
+            this.platform.type === 'cloud')
+            throw new Error(`Web Almond can only connect to publicly accessible Home Assistant instances`);
+
         // start asynchronously as to not block Home Assistant from starting
         // while it's waiting for /devices/create to return (which causes us
         // to fail to connect)

--- a/test/data/credentials/io.home-assistant.json
+++ b/test/data/credentials/io.home-assistant.json
@@ -1,5 +1,6 @@
 {
     "kind": "io.home-assistant",
     "hassUrl": "http://127.0.0.1:8123",
-    "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkMzQ1NDY2MmJjZmI0OWJlYjk0YTg5MzhmNzY3NWI3ZiIsImlhdCI6MTYxODU2NzE4MiwiZXhwIjoxOTMzOTI3MTgyfQ.tQ8E2YkUIPYf0NjvcNsR7r1A7jLRQXp0Np4jdxPdDaM"
+    "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkMzQ1NDY2MmJjZmI0OWJlYjk0YTg5MzhmNzY3NWI3ZiIsImlhdCI6MTYxODU2NzE4MiwiZXhwIjoxOTMzOTI3MTgyfQ.tQ8E2YkUIPYf0NjvcNsR7r1A7jLRQXp0Np4jdxPdDaM",
+    "ownerTier": "desktop:abcdef0123456789"
 }


### PR DESCRIPTION
Ensure that the Home Assistant gateway device has the right
ownerTier property so it won't be started if it is configured
through cloud sync (which would not be possible because direct
local connection is necessary). Also, move the cloud check to
the start() method instead of the constructor so the device
can be loaded in the cloud (even though it is ineffective)
without being autodeleted.