### PR TITLE
com.smartnews: remove full body from API

### DIFF
--- a/main/com.smartnews/index.js
+++ b/main/com.smartnews/index.js
@@ -88,7 +88,6 @@ async function* tryGetArticle(forDate) {
                     source: article.site ? article.site.name : null,
                     author: article.author ? article.author.name : null,
                     audio_url: s3tohttp(article.summary_mp3_file),
-                    content: sanitize(article.body),
                 };
             } catch(e) {
                 if (e.name !== 'SyntaxError')

--- a/main/com.smartnews/manifest.tt
+++ b/main/com.smartnews/manifest.tt
@@ -85,7 +85,8 @@ class @com.smartnews
                                     base_projection=['publisher', 'company', 'media'],
                                     passive_verb_projection=['published | by', 'released | by'],
                                     reverse_verb_projection=['released', 'published']
-                                 }],
+                                 }]
+                                 /*,
                                  out content: String
                                  #[string_values="tt:long_free_text"]
                                  #_[canonical={
@@ -93,7 +94,7 @@ class @com.smartnews
                                     base = ["news content", "content", "body", "article"],
                                     property = ["news #", "content #", "body #"]
                                  }]
-                                 #[filterable=false]
+                                 #[filterable=false]*/
                                  )
   #_[canonical=["news article", "news report",
                "news",


### PR DESCRIPTION
It causes the skill to return an enormous amount of text that
chokes everything else.