### PR TITLE
Spotify: survive if no AudioController player is available

### DIFF
--- a/main/com.bing/eval/scenarios.txt
+++ b/main/com.bing/eval/scenarios.txt
@@ -14,14 +14,7 @@ A: 2 \+ 3 is equal to 5\.
 A: >> expecting = null
 
 ====
-# 3-dialogue-handler-timezone
-
-U: what time is it in tunisi
-A: Right now it is .* in Tunis, Tunisia\.
-A: >> expecting = null
-
-====
-# 4-dialogue-handler-explicit
+# 3-dialogue-handler-explicit
 
 U: ask bing about pangolins
 A: (I found Pangolin - Wikipedia\. )?Pangolins, sometimes known as scaly anteaters, are mammals .*


### PR DESCRIPTION
If we're trying to control the Spotify app from the web (or from
genie-desktop) we won't have a registered audio player. Instead,
we'll just use the Spotify APIs to learn about available devices
and control them.